### PR TITLE
Adds labels to conform to RH enterprise contract

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -1,4 +1,4 @@
-#Build stage
+# Build stage
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
 
 LABEL description="Cosign is a container signing tool that leverages simple, secure, and auditable signatures based on simple primitives and best practices."
@@ -13,8 +13,8 @@ USER root
 RUN git config --global --add safe.directory /cosign
 RUN make cosign
 
-#Install Cosign
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Install Cosign
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
 RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign
 

--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -1,12 +1,19 @@
 #Build stage
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+
+LABEL description="Cosign is a container signing tool that leverages simple, secure, and auditable signatures based on simple primitives and best practices."
+LABEL io.k8s.description="Cosign is a container signing tool that leverages simple, secure, and auditable signatures based on simple primitives and best practices."
+LABEL io.k8s.display-name="Cosign container image for Red Hat Trusted Signer"
+LABEL io.openshift.tags="cosign trusted-signer"
+LABEL summary="Provides the cosign CLI binary for signing and verifying container images."
+
 WORKDIR /cosign
 COPY . .
 USER root
 RUN git config --global --add safe.directory /cosign
 RUN make cosign
 
-#Install Cosign 
+#Install Cosign
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
 RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign


### PR DESCRIPTION
All Red Hat products produced via RHTAP are required to use the Red Hat "enterprise contract" integration test, found here: https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract-redhat.yaml.

This commit adds labels to the Dockerfile, overriding certain inherited labels. In some cases, the enterprise contract disallows labels to be inherited. This should resolve those failing checks.

I've also updated the run image to use ubi9 as a base image, with the latest SHA.