### PR TITLE
Use hermetic builds and prefetched input

### DIFF
--- a/.tekton/cosign-pull-request.yaml
+++ b/.tekton/cosign-pull-request.yaml
@@ -99,10 +99,12 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
+      value: "true"
     - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
+      value: '{"type": "gomod", "path": "."}'
     - default: "false"
       description: Java build
       name: java

--- a/.tekton/cosign-push.yaml
+++ b/.tekton/cosign-push.yaml
@@ -96,10 +96,12 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
+      value: "true"
     - default: ""
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
+      value: '{"type": "gomod", "path": "."}'
     - default: "false"
       description: Java build
       name: java


### PR DESCRIPTION
This should satisfy enterprise contract checks for RHTAP.