### PR TITLE
chore: don't force push the release branch

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -82,9 +82,6 @@ git add . # Adds applied patches
 git add $custom_files # Adds custom files
 git commit -m "${redhat_files_msg}"
 
-# Push the release-next branch
-git push -f origin "${redhat_ref}"
-
 # Trigger CI
 # TODO: Set up openshift or github CI to run on release-next-ci
 git checkout "${redhat_ref}" -B "${redhat_ref}"-ci


### PR DESCRIPTION
The overall strategy with our sync script is:
- Maintain a branch with overlays and modifications to the upstream (`main` and `midstream-vX.Y.Z`)
- Maintain a branch which mirrors upstream with our overlays and modifications applied (`release-next` and `redhat-vX.Y.Z`). This includes the rhtap `.tekton` folder, which needs to be treated specially because rhtap cannot support writing these to a branch other than the one that is to be built by rhtap, i.e. the `redhat-vX.Y.Z`  branch.

There is currently also a `release-next-ci` and `redhat-vX.Y.Z-ci` branch which is applied via the PR which is created from the update-to-head.sh script.

At the moment, we force push both the `redhat-vX.Y.Z` and `redhat-vX.Y.Z-ci` branches. But I don’t think we need to actually force push the release branch only the `*-ci` branches.

This is all cribbed from the Serverless project. We’ve made a bunch of modifications to address tracking release refs and such. But the overall structure and idea is the same.

But the more I try and think through scenarios where we actually need to force push the release branch, the less it seems necessary.