### PR TITLE
Renamed linux cosign binary to be just "cosign".

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -7,7 +7,6 @@ USER root
 RUN git config --global --add safe.directory /cosign
 RUN make cross
 RUN gzip cosign-darwin-amd64
-RUN gzip cosign-linux-amd64
 RUN gzip cosign-windows-amd64
 
 # Install Cosign
@@ -21,11 +20,12 @@ LABEL summary="Provides the cosign CLI binary for signing and verifying containe
 LABEL com.redhat.component="cosign"
 
 COPY --from=build-env /cosign/cosign-darwin-amd64.gz /usr/local/bin/cosign-darwin-amd64.gz
-COPY --from=build-env /cosign/cosign-linux-amd64.gz /usr/local/bin/cosign-linux-amd64.gz
+COPY --from=build-env /cosign/cosign-linux-amd64 /usr/local/bin/cosign-linux-amd64
 COPY --from=build-env /cosign/cosign-windows-amd64.gz /usr/local/bin/cosign-windows-amd64.gz
+RUN mv /usr/local/bin/cosign-linux-amd64 /usr/local/bin/cosign
 
 RUN chown root:0 /usr/local/bin/cosign-darwin-amd64.gz && chmod g+wx /usr/local/bin/cosign-darwin-amd64.gz 
-RUN chown root:0 /usr/local/bin/cosign-linux-amd64.gz && chmod g+wx /usr/local/bin/cosign-linux-amd64.gz
+RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign
 RUN chown root:0 /usr/local/bin/cosign-windows-amd64.gz && chmod g+wx /usr/local/bin/cosign-windows-amd64.gz
 
 #Configure home directory


### PR DESCRIPTION
It completely slipped my mind that cosign was used on cluster. This should address that issue.