### PR TITLE
SECURESIGN-190 | swap to go-tools builder image

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -1,14 +1,5 @@
-# Build stage
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder AS build-env
 
-WORKDIR /cosign
-COPY . .
-USER root
-RUN git config --global --add safe.directory /cosign
-RUN make cosign
-
-# Install Cosign
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:9a0f860e143f2f771bee92ab3b0161e10e2390370152e07e6bcf8105242cee13
 
 LABEL description="Cosign is a container signing tool that leverages simple, secure, and auditable signatures based on simple primitives and best practices."
 LABEL io.k8s.description="Cosign is a container signing tool that leverages simple, secure, and auditable signatures based on simple primitives and best practices."
@@ -17,14 +8,16 @@ LABEL io.openshift.tags="cosign trusted-signer"
 LABEL summary="Provides the cosign CLI binary for signing and verifying container images."
 LABEL com.redhat.component="cosign"
 
-COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
-RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign
-
-#Configure home directory
+WORKDIR /cosign
+USER root
+COPY . .
 ENV HOME=/home
-RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
-
 WORKDIR ${HOME}
+
+RUN git config --global --add safe.directory /cosign && \
+    cd /cosign && make cosign && mv /cosign/cosign /usr/local/bin/cosign && \
+    chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign  && \
+    chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 
 # Makes sure the container stays running
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Tested by copying the dockerfile into the branch `midstream/midstream-v2.2.0` and works like a charm. Ready for review and QE.
/cc @osmman 
/cc @lance 