### PR TITLE
[SECURESIGN-361] update cronjob for redhat-v1.2

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -4,13 +4,13 @@ on:
   schedule:
     # Every M-F at 12:00am run this job
     - cron:  "0 0 * * 1-5"
-    
+
 jobs:
   check-image-version:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
     strategy:
       matrix:
-        branch: [main, midstream-v2.1.1, midstream-v2.2.0]
+        branch: [main, redhat-v2.2]
     with:
       branch: ${{ matrix.branch }}
     secrets:


### PR DESCRIPTION
Removes the midstream-v* branches and uses the production branch for TP2, `redhat-v1.2`.