### PR TITLE
docker: keep cosign-linux-amd64 - cp instead of mv

### DIFF
--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -35,14 +35,15 @@ COPY --from=build-env /cosign/cosign-linux-arm64.gz /usr/local/bin/cosign-linux-
 COPY --from=build-env /cosign/cosign-linux-ppc64le.gz /usr/local/bin/cosign-linux-ppc64le.gz
 COPY --from=build-env /cosign/cosign-linux-s390x.gz /usr/local/bin/cosign-linux-s390x.gz
 
-RUN mv /usr/local/bin/cosign-linux-amd64 /usr/local/bin/cosign && \
+RUN cp /usr/local/bin/cosign-linux-amd64 /usr/local/bin/cosign && \
     chown root:0 /usr/local/bin/cosign-darwin-amd64.gz && chmod g+wx /usr/local/bin/cosign-darwin-amd64.gz && \
+    chown root:0 /usr/local/bin/cosign-linux-amd64 && chmod g+wx /usr/local/bin/cosign-linux-amd64 && \
     chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign && \
     chown root:0 /usr/local/bin/cosign-windows-amd64.gz && chmod g+wx /usr/local/bin/cosign-windows-amd64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-arm64.gz && chmod g+wx /usr/local/bin/cosign-linux-arm64.gz && \
     chown root:0 /usr/local/bin/cosign-darwin-arm64.gz && chmod g+wx /usr/local/bin/cosign-darwin-arm64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-ppc64le.gz && chmod g+wx /usr/local/bin/cosign-linux-ppc64le.gz && \
-    chown root:0 /usr/local/bin/cosign-linux-s390x.gz && chmod g+wx /usr/local/bin/cosign-linux-s390x.gz 
+    chown root:0 /usr/local/bin/cosign-linux-s390x.gz && chmod g+wx /usr/local/bin/cosign-linux-s390x.gz
 
 ##Configure home directory
 ENV HOME=/home


### PR DESCRIPTION
Instead of moving the binary to be named `cosign`, this change modifies the Dockerfile so that the binary is copied to the new, shortened name, leaving the original, more descriptive name. This simplifies its usage in other images, such as the CLI download image where the original name is desired.