### PR TITLE
chore(docker): ensure an executable cosign

### DIFF
--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -10,11 +10,13 @@ RUN git config --global --add safe.directory /cosign && \
     git stash pop && \
     go mod vendor && \
     make -f Build.mak cross-platform && \
-    gzip cosign-darwin-amd64 && \
-    gzip cosign-darwin-arm64 && \
+    cp cosign-linux-amd64 cosign && \
+    gzip cosign-linux-amd64 && \
     gzip cosign-linux-ppc64le && \
     gzip cosign-linux-s390x && \
     gzip cosign-linux-arm64 && \
+    gzip cosign-darwin-amd64 && \
+    gzip cosign-darwin-arm64 && \
     gzip cosign-windows-amd64
 
 # Install Cosign
@@ -28,20 +30,21 @@ LABEL summary="Provides the cosign CLI binary for signing and verifying containe
 LABEL com.redhat.component="cosign"
 
 COPY --from=build-env /cosign/cosign-darwin-amd64.gz /usr/local/bin/cosign-darwin-amd64.gz
-COPY --from=build-env /cosign/cosign-linux-amd64 /usr/local/bin/cosign-linux-amd64
 COPY --from=build-env /cosign/cosign-windows-amd64.gz /usr/local/bin/cosign-windows-amd64.gz
 COPY --from=build-env /cosign/cosign-darwin-arm64.gz /usr/local/bin/cosign-darwin-arm64.gz
 COPY --from=build-env /cosign/cosign-linux-arm64.gz /usr/local/bin/cosign-linux-arm64.gz
 COPY --from=build-env /cosign/cosign-linux-ppc64le.gz /usr/local/bin/cosign-linux-ppc64le.gz
 COPY --from=build-env /cosign/cosign-linux-s390x.gz /usr/local/bin/cosign-linux-s390x.gz
+COPY --from=build-env /cosign/cosign-linux-amd64.gz /usr/local/bin/cosign-linux-amd64.gz
+COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
 
-RUN cp /usr/local/bin/cosign-linux-amd64 /usr/local/bin/cosign && \
+RUN chown root:0 /usr/local/bin/cosign && \
+    chmod g+wx /usr/local/bin/cosign && \
     chown root:0 /usr/local/bin/cosign-darwin-amd64.gz && chmod g+wx /usr/local/bin/cosign-darwin-amd64.gz && \
-    chown root:0 /usr/local/bin/cosign-linux-amd64 && chmod g+wx /usr/local/bin/cosign-linux-amd64 && \
-    chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign && \
+    chown root:0 /usr/local/bin/cosign-darwin-arm64.gz && chmod g+wx /usr/local/bin/cosign-darwin-arm64.gz && \
     chown root:0 /usr/local/bin/cosign-windows-amd64.gz && chmod g+wx /usr/local/bin/cosign-windows-amd64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-arm64.gz && chmod g+wx /usr/local/bin/cosign-linux-arm64.gz && \
-    chown root:0 /usr/local/bin/cosign-darwin-arm64.gz && chmod g+wx /usr/local/bin/cosign-darwin-arm64.gz && \
+    chown root:0 /usr/local/bin/cosign-linux-amd64.gz && chmod g+wx /usr/local/bin/cosign-linux-amd64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-ppc64le.gz && chmod g+wx /usr/local/bin/cosign-linux-ppc64le.gz && \
     chown root:0 /usr/local/bin/cosign-linux-s390x.gz && chmod g+wx /usr/local/bin/cosign-linux-s390x.gz
 


### PR DESCRIPTION
Ensures that there is an executable `/usr/local/bin/cosign` as well as a gzipped version of the arch-named binary.