### PR TITLE
Update ec build sha cli image

### DIFF
--- a/Dockerfile.client-server-re.rh
+++ b/Dockerfile.client-server-re.rh
@@ -2,7 +2,7 @@
 
 
 FROM quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-cli@sha256:5c56a63e98d90f6d6974dbb297dda9f1a0892aac46fbb4307b3b14b01cc758dc as rekor
-FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/cli-v02:c862b0f77bb10082d1440e0d4b6a4e9645b83382 as ec
+FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/cli-v02@sha256:5624cb2a696679f82f25ae95be40b138eda1bf071b6fcd9177b7cd2da4ae7aa5 as ec
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:119ac25920c8bb50c8b5fd75dcbca369bf7d1f702b82f3d39663307890f0bf26
 


### PR DESCRIPTION
Contains ec v0.2.3 built on git sha
c21271a0ee838b676e0cdd955d752cbc8630a347 in the
enterprise-contract/ec-cli repo.

Note that the previous image was specified using an image tag, not the image digest, so that's why the diff looks like it does.