### PR TITLE
Add license preamble to two files

### DIFF
--- a/internal/ui/index.go
+++ b/internal/ui/index.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ui
 
 const (

--- a/release-plans/gamma/ReleasePlan.yaml
+++ b/release-plans/gamma/ReleasePlan.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:


### PR DESCRIPTION
The license check CI was failing. This should make it pass.

Done like this:
```
  podman run -it -v ${PWD}:/src ghcr.io/google/addlicense \
    -l apache -c 'The Sigstore Authors' -ignore "third_party/**" -v *
```

See also license-check in .github/workflows/tests.yaml.