### PR TITLE
fix: add-exe-extension-to-cosign pt1

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -35,4 +35,4 @@ cosign-linux-s390x:  ## Build for Linux s390x
 
 .PHONY: cosign-windows-amd64
 cosign-windows-amd64: ## Build for Windows
-	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o cosign-windows-amd64 -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o cosign-windows-amd64.exe -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign

--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -28,6 +28,7 @@ LABEL io.k8s.display-name="Cosign container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="cosign trusted-signer"
 LABEL summary="Provides the cosign CLI binary for signing and verifying container images."
 LABEL com.redhat.component="cosign"
+LABEL name="cosign"
 
 COPY --from=build-env /cosign/cosign-darwin-amd64.gz /usr/local/bin/cosign-darwin-amd64.gz
 COPY --from=build-env /cosign/cosign-windows-amd64.exe.gz /usr/local/bin/cosign-windows-amd64.exe.gz

--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -17,7 +17,7 @@ RUN git config --global --add safe.directory /cosign && \
     gzip cosign-linux-arm64 && \
     gzip cosign-darwin-amd64 && \
     gzip cosign-darwin-arm64 && \
-    gzip cosign-windows-amd64
+    gzip cosign-windows-amd64.exe
 
 # Install Cosign
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:119ac25920c8bb50c8b5fd75dcbca369bf7d1f702b82f3d39663307890f0bf26
@@ -30,7 +30,7 @@ LABEL summary="Provides the cosign CLI binary for signing and verifying containe
 LABEL com.redhat.component="cosign"
 
 COPY --from=build-env /cosign/cosign-darwin-amd64.gz /usr/local/bin/cosign-darwin-amd64.gz
-COPY --from=build-env /cosign/cosign-windows-amd64.gz /usr/local/bin/cosign-windows-amd64.gz
+COPY --from=build-env /cosign/cosign-windows-amd64.exe.gz /usr/local/bin/cosign-windows-amd64.exe.gz
 COPY --from=build-env /cosign/cosign-darwin-arm64.gz /usr/local/bin/cosign-darwin-arm64.gz
 COPY --from=build-env /cosign/cosign-linux-arm64.gz /usr/local/bin/cosign-linux-arm64.gz
 COPY --from=build-env /cosign/cosign-linux-ppc64le.gz /usr/local/bin/cosign-linux-ppc64le.gz
@@ -42,7 +42,7 @@ RUN chown root:0 /usr/local/bin/cosign && \
     chmod g+wx /usr/local/bin/cosign && \
     chown root:0 /usr/local/bin/cosign-darwin-amd64.gz && chmod g+wx /usr/local/bin/cosign-darwin-amd64.gz && \
     chown root:0 /usr/local/bin/cosign-darwin-arm64.gz && chmod g+wx /usr/local/bin/cosign-darwin-arm64.gz && \
-    chown root:0 /usr/local/bin/cosign-windows-amd64.gz && chmod g+wx /usr/local/bin/cosign-windows-amd64.gz && \
+    chown root:0 /usr/local/bin/cosign-windows-amd64.exe.gz && chmod g+wx /usr/local/bin/cosign-windows-amd64.exe.gz && \
     chown root:0 /usr/local/bin/cosign-linux-arm64.gz && chmod g+wx /usr/local/bin/cosign-linux-arm64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-amd64.gz && chmod g+wx /usr/local/bin/cosign-linux-amd64.gz && \
     chown root:0 /usr/local/bin/cosign-linux-ppc64le.gz && chmod g+wx /usr/local/bin/cosign-linux-ppc64le.gz && \


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SECURESIGN-777

## Important
This is part one of this ticket this needs to be merged before pt2 can be, adds the .exe extension to the cosign binary for windows 