### PR TITLE
add .exe extension to binarys  after gunzip

### DIFF
--- a/Dockerfile.client-server-cg.rh
+++ b/Dockerfile.client-server-cg.rh
@@ -17,7 +17,7 @@ COPY --from=cosign /usr/local/bin/cosign-linux-amd64.gz   $APP_ROOT/src/clients/
 COPY --from=cosign /usr/local/bin/cosign-linux-arm64.gz   $APP_ROOT/src/clients/linux/cosign-arm64.gz
 COPY --from=cosign /usr/local/bin/cosign-linux-ppc64le.gz $APP_ROOT/src/clients/linux/cosign-ppc64le.gz
 COPY --from=cosign /usr/local/bin/cosign-linux-s390x.gz   $APP_ROOT/src/clients/linux/cosign-s390x.gz
-COPY --from=cosign /usr/local/bin/cosign-windows-amd64.exe.gz $APP_ROOT/src/clients/windows/cosign-amd64.gz
+COPY --from=cosign /usr/local/bin/cosign-windows-amd64.exe.gz $APP_ROOT/src/clients/windows/cosign-amd64.exe.gz
 
 COPY --from=gitsign /usr/local/bin/gitsign_cli_darwin_amd64.gz      $APP_ROOT/src/clients/darwin/gitsign-amd64.gz
 COPY --from=gitsign /usr/local/bin/gitsign_cli_darwin_arm64.gz      $APP_ROOT/src/clients/darwin/gitsign-arm64.gz
@@ -25,7 +25,7 @@ COPY --from=gitsign /usr/local/bin/gitsign_cli_linux_amd64.gz       $APP_ROOT/sr
 COPY --from=gitsign /usr/local/bin/gitsign_cli_linux_arm64.gz       $APP_ROOT/src/clients/linux/gitsign-arm64.gz
 COPY --from=gitsign /usr/local/bin/gitsign_cli_linux_ppc64le.gz     $APP_ROOT/src/clients/linux/gitsign-ppc64le.gz
 COPY --from=gitsign /usr/local/bin/gitsign_cli_linux_s390x.gz       $APP_ROOT/src/clients/linux/gitsign-s390x.gz
-COPY --from=gitsign /usr/local/bin/gitsign_cli_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/gitsign-amd64.gz
+COPY --from=gitsign /usr/local/bin/gitsign_cli_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/gitsign-amd64.exe.gz
 
 
 LABEL \

--- a/Dockerfile.client-server-re.rh
+++ b/Dockerfile.client-server-re.rh
@@ -19,7 +19,7 @@ COPY --from=rekor /usr/local/bin/rekor_cli_linux_amd64.gz       $APP_ROOT/src/cl
 COPY --from=rekor /usr/local/bin/rekor_cli_linux_arm64.gz       $APP_ROOT/src/clients/linux/rekor-cli-arm64.gz
 COPY --from=rekor /usr/local/bin/rekor_cli_linux_ppc64le.gz     $APP_ROOT/src/clients/linux/rekor-cli-ppc64le.gz
 COPY --from=rekor /usr/local/bin/rekor_cli_linux_s390x.gz       $APP_ROOT/src/clients/linux/rekor-cli-s390x.gz
-COPY --from=rekor /usr/local/bin/rekor_cli_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/rekor-cli-amd64.gz
+COPY --from=rekor /usr/local/bin/rekor_cli_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/rekor-cli-amd64.exe.gz
 
 COPY --from=ec /usr/local/bin/ec_darwin_amd64.gz      $APP_ROOT/src/clients/darwin/ec-amd64.gz
 COPY --from=ec /usr/local/bin/ec_darwin_arm64.gz      $APP_ROOT/src/clients/darwin/ec-arm64.gz
@@ -27,7 +27,7 @@ COPY --from=ec /usr/local/bin/ec_linux_amd64.gz       $APP_ROOT/src/clients/linu
 COPY --from=ec /usr/local/bin/ec_linux_arm64.gz       $APP_ROOT/src/clients/linux/ec-arm64.gz
 COPY --from=ec /usr/local/bin/ec_linux_ppc64le.gz     $APP_ROOT/src/clients/linux/ec-ppc64le.gz
 COPY --from=ec /usr/local/bin/ec_linux_s390x.gz       $APP_ROOT/src/clients/linux/ec-s390x.gz
-COPY --from=ec /usr/local/bin/ec_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/ec-amd64.gz
+COPY --from=ec /usr/local/bin/ec_windows_amd64.exe.gz $APP_ROOT/src/clients/windows/ec-amd64.exe.gz
 
 LABEL \
       com.redhat.component="trusted-artifact-signer-serve-cli-container-re" \


### PR DESCRIPTION
The CLI images, still functions as an executable on windows, but when using gunzip the .exe extension isn't there 