### PR TITLE
Bump ec-cli reference to latest digest

### DIFF
--- a/Dockerfile.client-server-re.rh
+++ b/Dockerfile.client-server-re.rh
@@ -2,7 +2,7 @@
 
 
 FROM quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-cli@sha256:c0f25ceca5534dc597904293cf376bcbedefe0d90322fd7b136c913e3bc059a6 as rekor
-FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v04/cli-v04@sha256:8c766da37d73bf07ecdd9154b64a6525e4f5ed55321b4871dc370a31e488fd18 as ec
+FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v04/cli-v04@sha256:499b4b56769e18b698c328312d92db0c58f7c32e0e91aa4a821c33aa65737a05 as ec
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:29790f898839e92c0554d031856e1770254f27e66af593fc088fbb7d3e5e298e
 


### PR DESCRIPTION
The ec version is `v0.4.79+redhat` built on sha 9faa387. The image is identical to `registry.redhat.io/rhtas/ec-rhel9:0.4-1718293643`.

Should resolve SECURESIGN-1054. See also https://github.com/enterprise-contract/ec-cli/pull/1697 .