### PR TITLE
fix(SECURESIGN-1179): include version metadata

### DIFF
--- a/.github/workflows/kind-e2e-insecure-registry.yaml
+++ b/.github/workflows/kind-e2e-insecure-registry.yaml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.x
         - v1.25.x
         - v1.26.x
         - v1.27.x

--- a/.github/workflows/whitespace.yaml
+++ b/.github/workflows/whitespace.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: chainguard-dev/actions/trailing-space@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+      - uses: chainguard-dev/actions/trailing-space@7071df0659dbd4a79804731f0da2d0f1dba0b356 # main
         if: ${{ always() }}
 
       - uses: chainguard-dev/actions/eof-newline@84c993eaf02da1c325854fb272a4df9184bd80fc # main

--- a/Build.mak
+++ b/Build.mak
@@ -1,12 +1,25 @@
 
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --no-show-signature --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
 
 LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
         -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
         -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
         -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
 
-.PHONY: 
+.PHONY:
 cross-platform: cosign-darwin-arm64 cosign-darwin-amd64 cosign-linux-amd64 cosign-linux-arm64 cosign-linux-ppc64le cosign-linux-s390x cosign-windows-amd64 ## Build all distributable (cross-platform) binaries
 
 .PHONY:	cosign-darwin-arm64
@@ -17,7 +30,7 @@ cosign-darwin-arm64: ## Build for mac M1
 cosign-darwin-amd64:  ## Build for Darwin (macOS)
 	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o cosign-darwin-amd64 -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign
 
-.PHONY: cosign-linux-amd64 
+.PHONY: cosign-linux-amd64
 cosign-linux-amd64: ## Build for Linux amd64
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cosign-linux-amd64 -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign
 

--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -7,6 +7,8 @@ USER root
 RUN git config --global --add safe.directory /cosign && \
     git stash && \
     export GIT_VERSION=$(git describe --tags --always --dirty) && \
+    export GIT_HASH=$(git rev-parse HEAD) && \
+    export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') && \
     git stash pop && \
     go mod vendor && \
     make -f Build.mak cross-platform && \


### PR DESCRIPTION
The konflux build does not include all the necessary metadata for the `cosign version` command. This change should ensure that the command produces the correct information.

`cosign version` output for a local build now looks like this

```
podman run localhost/cosign-test:latest cosign version
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    rhtas-1.0.2-7-g8ee49d4f
GitCommit:     8ee49d4f534ff56e75916fd7426afe8796f37c55
GitTreeState:  dirty
BuildDate:     2024-07-01T19:16:20Z
GoVersion:     go1.21.3
Compiler:      gc
Platform:      linux/amd64
```

EDIT: Some updates to the github actions workflow files were also needed to pass PR checks