### PR TITLE
chore(deps): Update ec cli digest to newer version

### DIFF
--- a/Dockerfile.client-server-re.rh
+++ b/Dockerfile.client-server-re.rh
@@ -2,7 +2,7 @@
 
 
 FROM quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-cli@sha256:c0f25ceca5534dc597904293cf376bcbedefe0d90322fd7b136c913e3bc059a6 as rekor
-FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v04/cli-v04@sha256:499b4b56769e18b698c328312d92db0c58f7c32e0e91aa4a821c33aa65737a05 as ec
+FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v04/cli-v04@sha256:013fed3832c831cfa45ecad66ba335ebb0438ade168174d474c0ed1ac3c2c59c as ec
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:82fad27b91361473d919522a01a1198f327230bf8d2b569a8995bdcd6ac7cb94
 


### PR DESCRIPTION
The newer ec-cli image contains the following ec version:
```
  Version            v0.4.82+redhat
  Source ID          e513427c2a98e2d6b0ef6c95ed5a83af741c4276
  Change date        2024-07-01 15:27:07 +0000 UTC (2 weeks ago)
```

[Changes](https://github.com/enterprise-contract/ec-cli/compare/9faa38736ba8af53bcfef760b2d8359aa8e91cf1...e513427c2a98e2d6b0ef6c95ed5a83af741c4276).

There are no functional changes. The significant change is that one dependency was upgraded.

Note: This kind of commit should be created automatically once we have Konflux nudging configured correctly for the ec-cli component, see [EC-691](https://issues.redhat.com/browse/EC-691). 