### PR TITLE
Upgrade Enterprise Contract from v0.4 to v0.5

### DIFF
--- a/Dockerfile.client-server-re.rh
+++ b/Dockerfile.client-server-re.rh
@@ -2,7 +2,7 @@
 
 
 FROM quay.io/securesign/rekor-cli@sha256:0f874a33e5ee36ed6cdb080e1774a6d66d3c095458f8a138b5c0f95fd8f32944 as rekor
-FROM registry.redhat.io/rhtas/ec-rhel9:0.4@sha256:4199d2db9ff18b37f6ec84ea3a0e973fd4e36262f16785e0c9419ef4224d4749 as ec
+FROM registry.redhat.io/rhtas/ec-rhel9:0.5@sha256:815110eec64d0d7fb4af003e86c261234b165bcfde8012f0891eba6c0c419b4e as ec
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998
 

--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -7,7 +7,7 @@ FROM quay.io/securesign/fetch-tsa-certs@sha256:04ee10dd6f36b7ebca80c0e7badeb5c69
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
 FROM quay.io/securesign/rekor-cli@sha256:0f874a33e5ee36ed6cdb080e1774a6d66d3c095458f8a138b5c0f95fd8f32944 as rekor
-FROM registry.redhat.io/rhtas/ec-rhel9:0.4@sha256:4199d2db9ff18b37f6ec84ea3a0e973fd4e36262f16785e0c9419ef4224d4749 as ec
+FROM registry.redhat.io/rhtas/ec-rhel9:0.5@sha256:815110eec64d0d7fb4af003e86c261234b165bcfde8012f0891eba6c0c419b4e as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
 FROM quay.io/securesign/trillian-createtree@sha256:2a17108678e51bf39d80b3a7fc577ec9c12de10e19286e3e5298fb8cfcf9309c as trillian-createtree


### PR DESCRIPTION
The v0.5 release branch was split from main branch recently. This is the latest image built from that branch.

```
$ podman run --rm registry.redhat.io/rhtas/ec-rhel9:0.5 version
Version            v0.5.149+redhat
Source ID          76de2bf70f367f6d874cb77dde3828000853eb6a
Change date        2024-09-12 15:59:32 +0000 UTC (5 hours ago)
...
```

See also:
https://github.com/enterprise-contract/ec-cli/compare/release-v0.4...76de2bf70f

Ref: https://issues.redhat.com/browse/EC-819