### PR TITLE
Upgrade Conforma/EC cli from v0.6 to v0.7

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -7,7 +7,7 @@ FROM quay.io/securesign/fetch-tsa-certs@sha256:acb15dc04a3cfbb0431ac237fe3e27120
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
 FROM quay.io/securesign/rekor-cli@sha256:7a47b37bfeebe2e95b90333869fda68d87587ff65aac7ce1c777ae75e882450a as rekor
-FROM registry.redhat.io/rhtas/ec-rhel9:0.6@sha256:c18452e9884d5f7f7e51adfb3dd5bf1c5b842f6bc28543cb4d084bb3ab02d88b as ec
+FROM registry.redhat.io/rhtas/ec-rhel9:0.7@sha256:9338ab2039ae8f6f377c68fdd57eb5f535fb233761609479f221b7763e2204de as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
 FROM quay.io/securesign/trillian-createtree@sha256:812315ab0ef006799ebe158dff67773b56d5d5e86d07dee9341214d1b49f4542 as trillian-createtree


### PR DESCRIPTION
The Conforma CLI release-v0.7 branch was split from main branch recently. This is the latest image built from that release branch.

The intention is that Conforma v0.7 should be included in the RHTAS 1.3 release, and tested/shipped with with the next RHADS-SSC/RHTAP release.

### Confirming the build version:
```
$ podman run --rm -it registry.redhat.io/rhtas/ec-rhel9:0.7@sha256:9338ab2039ae8f6f377c68fdd57eb5f535fb233761609479f221b7763e2204de version | head -3
Version            v0.7.152+redhat
Source ID          8bb242ea5c948846ccc8bb7cb8b27c9fd3ab76ff
Change date        2025-08-25 19:42:22 +0000 UTC (1 day ago)
```

### Inspecting the cross-platform binaries:
```
podman run --rm --entrypoint /bin/bash registry.redhat.io/rhtas/ec-rhel9:0.7@sha256:9338ab2039ae8f6f377c68fdd57eb5f535fb233761609479f221b7763e2204de  -c "ls -l /usr/local/bin"
total 455144
-rwxr-xr-x. 1 root root 120619928 Aug 25 19:48 ec
-rwxr-xr-x. 1 root root  36037032 Aug 25 19:46 ec_darwin_amd64.gz
-rw-r--r--. 1 root root       119 Aug 25 19:46 ec_darwin_amd64.sha256.gz
-rwxr-xr-x. 1 root root  33703974 Aug 25 19:47 ec_darwin_arm64.gz
-rw-r--r--. 1 root root       119 Aug 25 19:47 ec_darwin_arm64.sha256.gz
-rwxr-xr-x. 1 root root  35391031 Aug 25 19:48 ec_linux_amd64.gz
-rw-r--r--. 1 root root       119 Aug 25 19:48 ec_linux_amd64.sha256.gz
-rwxr-xr-x. 1 root root  31945389 Aug 25 19:49 ec_linux_arm64.gz
-rw-r--r--. 1 root root       120 Aug 25 19:49 ec_linux_arm64.sha256.gz
-rwxr-xr-x. 1 root root  31457987 Aug 25 19:50 ec_linux_ppc64le.gz
-rw-r--r--. 1 root root       122 Aug 25 19:50 ec_linux_ppc64le.sha256.gz
-rwxr-xr-x. 1 root root  34769066 Aug 25 19:51 ec_linux_s390x.gz
-rw-r--r--. 1 root root       120 Aug 25 19:51 ec_linux_s390x.sha256.gz
-rwxr-xr-x. 1 root root  35945345 Aug 25 19:52 ec_windows_amd64.exe.gz
-rw-r--r--. 1 root root       129 Aug 25 19:52 ec_windows_amd64.exe.sha256.gz
-rwxr-xr-x. 1 root root 106141744 Aug 25 19:48 kubectl
-rwxr-xr-x. 1 root root      3375 Aug 25 19:42 reduce-snapshot.sh
```

### Main tracker:

- [EC-1384](https://issues.redhat.com/browse/EC-1384)

### See also:

- [All code changes](https://github.com/conforma/cli/compare/acaa315ecfaffa3a8cae5818d666067c5b74c595...8bb242ea5c948846ccc8bb7cb8b27c9fd3ab76ff)
- [rhtas/ec-rhel9](https://catalog.redhat.com/software/containers/rhtas/ec-rhel9/65f1f9dcfc649a18c6075de5) in the Red Hat Catalog
- [Konflux Application for v0.7](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-contract-tenant/applications/ec-v07/)
- [Release notes Jira](https://issues.redhat.com/browse/EC-1450)