### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cosign

### DIFF
--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -34,7 +34,8 @@ LABEL io.k8s.display-name="Cosign container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="cosign trusted-signer"
 LABEL summary="Provides the cosign CLI binary for signing and verifying container images."
 LABEL com.redhat.component="cosign"
-LABEL name="cosign"
+LABEL name="rhtas/cosign-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 COPY --from=build-env /cosign/cosign-darwin-amd64.gz /usr/local/bin/cosign-darwin-amd64.gz
 COPY --from=build-env /cosign/cosign-windows-amd64.exe.gz /usr/local/bin/cosign-windows-amd64.exe.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
