### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for client-server

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -91,7 +91,8 @@ RUN gzip /var/www/html/clients/linux/tuftool-amd64
 
 LABEL \
       com.redhat.component="trusted-artifact-signer-serve-cli-container" \
-      name="trusted-artifact-signer-serve-cli-container" \
+      name="rhtas/client-server-rhel9" \
+      cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9" \
       version="1.1.0" \
       summary="Red Hat serves Trusted Artifact Signer CLI binaries cosign, gitsign, rekor-cli, ec, fetch_tsa_certs, trillian-createtree and trillian-updatetree from an HTTP server" \
       description="Serves Trusted Artifact Signer CLI binaries cosign, gitsign, rekor-cli, ec, fetch_tsa_certs, trillian-createtree and trillian-updatetree from an HTTP server" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
