### PR TITLE
Update client images from build 2026-04-30

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:964a065ddc521a5940cc793b8ffb798b848bf143ae01053b4b7a963078025e9b AS cosign
-FROM quay.io/securesign/gitsign@sha256:7fc65d4ae6d14391497b5f8b67ffa893585bd50fdd119f06e41c3a8e30e4538f AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:05ece68f7590070bf10270558d74689026c408aeb0774df3556a62c2056a4dc1 AS cosign
+FROM quay.io/securesign/gitsign@sha256:ef13a35d0c06acdb23c7c914ee6005c436a97e01e5e8d5505cd53cb07dbe824a AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:ff3cf6f4b7b479ecc3a74755dd07dc83a9c7c4bb6e03d579ff9f3e85db52d296 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:c77afe555a41ecea68a81f34973e8a969a6f777de19bdf85163fa65f893fdcfc as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:afe79c8dd2a87762751d4251ba603fd77202c430cd9c6e5256f493c3a6a7b06c as rekor
+FROM quay.io/securesign/rekor-cli@sha256:d244f892515000472b3d1ef8a8126761a829dfe854eec3a63e45a2b16eebbbcc as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:9f77f00ee91d02801b78f78bad4bd3bfbe4ad0be273daf2fbd48bba0de46649a as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:65fe8e746878210d25b5e40c88329952bd3601f4e01f4d137efd4924d59ba1a7 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:63d823aecedc2fda116d7c89b53ef994fbd4f035640d403e734cf67e87750a2e as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:d70a9e83141ce9d27b4feba5803d04260d7028e17c5cacc158f4271e60d744e2 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:31ad6c6c802f9bd720f795e03a4f7825c6816abaa6372948f8337dbc8753c41d as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:892874c5cc063b3bda423cc25d2ed72954f4b3cdfbf9b8b5bbca6abe34425d72 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260430-073329-000`
- **tough-v1-3**: `tough-v1-3-20260430-073335-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260430-073343-000`

### Updated Images
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:63d823aecedc2fda116d7c89b53ef994fbd4f035640d403e734cf67e87750a2e`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:892874c5cc063b3bda423cc25d2ed72954f4b3cdfbf9b8b5bbca6abe34425d72`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:d70a9e83141ce9d27b4feba5803d04260d7028e17c5cacc158f4271e60d744e2`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:ef13a35d0c06acdb23c7c914ee6005c436a97e01e5e8d5505cd53cb07dbe824a`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:05ece68f7590070bf10270558d74689026c408aeb0774df3556a62c2056a4dc1`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:22c458ac6a0e15fd2e510a711e1c5486fd91d3248f58ffea3623a5abbb812c76`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:d244f892515000472b3d1ef8a8126761a829dfe854eec3a63e45a2b16eebbbcc`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:c77afe555a41ecea68a81f34973e8a969a6f777de19bdf85163fa65f893fdcfc`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-fk7xs`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-svtnn`
- gitsign-v1-3: `gitsign-v1-3-on-push-vvpbs`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-rk9pm`
- updatetree-v1-3: `updatetree-v1-3-on-push-s9s6t`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-sxbbb`
- tuffer-v1-3: `tuffer-v1-3-on-push-4pl7h`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-rhk2m`

🤖 Generated automatically by one-button-build.sh