### PR TITLE
fix: show Red Hat TAS success page on OIDC browser callback

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -144,7 +144,9 @@ func AuthenticateCaller(flow, idToken, oidcIssuer, oidcClientID, oidcClientSecre
 	case flowDevice:
 		tokenGetter = oauthflow.NewDeviceFlowTokenGetterForIssuer(oidcIssuer)
 	case flowNormal:
-		tokenGetter = oauthflow.DefaultIDTokenGetter
+		tokenGetter = &oauthflow.InteractiveIDTokenGetter{
+			HTMLPage: ui.RedHatInteractiveSuccessHTML,
+		}
 	case flowToken:
 		tokenGetter = &oauthflow.StaticTokenGetter{RawToken: idToken}
 	default:


### PR DESCRIPTION
ref: [SECURESIGN-4121](https://redhat.atlassian.net/browse/SECURESIGN-4121)