### PR TITLE
Update release-version to 1.3.5

### DIFF
--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/cosign-pull-request.yaml
+++ b/.tekton/cosign-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: dockerfile
     value: Dockerfile.cosign.rh
   - name: git-url

--- a/.tekton/cosign-push.yaml
+++ b/.tekton/cosign-push.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: dockerfile
     value: Dockerfile.cosign.rh
   - name: git-url


### PR DESCRIPTION
## Summary
- Update release-version parameter to 1.3.5 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)