### PR TITLE
Update client images from build 2026-05-11

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:a2955eab296d19ed4d0b83e3fb1894c5da8f175d778744abf0e64186eada0c1c AS cosign
-FROM quay.io/securesign/gitsign@sha256:3d873705943bde6394eda8700893da13cf1e7671f87b2794e3dda7b72c8ebcbb AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:0a20722c28c606664a41a6655c7fe141bbdde5e8309e31a1e49e5216fa2d18f3 AS cosign
+FROM quay.io/securesign/gitsign@sha256:f1fde22777495a17381daaa3cbb99746769c6e7ed1e84eb02a7928c7d749daa2 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:3e603d431de9994d16f4c0192bba556f0304498b007441a857e9d768f9a01581 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:150277d2c2c5845f2db54d1976bc97d0efbf5e6638909732e9667448a23385cc as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:0b151afea8b24d0a6a046cf79d6aa9de4a0474e1d404eaf70fa74b42f6c0f8b7 as rekor
+FROM quay.io/securesign/rekor-cli@sha256:878dc78b0064481da33b7adfaa2fa94278eb368d7253bb085f7c6058035296f2 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:98c1e1b8bfe382b956bfa176b70836e020050388f301a380d0f37c5e7e12fd1a as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:92b72e167985c50e6dedbc2e753c52164c70bf1e589f68e7aa61140759707d41 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:f36338f902bd18a95de9b9746303f82715d6a34e1a73bcdf5833d51e5a89d34b as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:1022fa308d15d2c9562dd2696b2b1603f486b4c14aa4c7a68e99a3b54233319f as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:c45e56769e47613bd49ac0d84ba009b2c3b50e8deec6e26a73fd7e230dd627fd as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:5453e207bf7f1f39ee8dca940f1a85c5fb601ac75a8bcc918998da3c4dd13a6a as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260511-082714-000`
- **tough-v1-3**: `tough-v1-3-20260511-082745-000-32`
- **create-tree-v1-3**: `create-tree-v1-3-20260511-082800-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260511-082745-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260511-083022-000-qc`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:fb9bd6b595ce9d2bac74eee0cb10217008a8944f6a94de1ae50e31ce8cc63f47`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:e4c8c71e3d89ce79ae7b6e51bd3b8272bb3953ab97ce790fd03d23ae21cc2a02`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:11df6bb271a3c98e396429a64b3f9d50d6ee774769b35c97077c5019ee44cb79`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:5f0dc895e1f761cbd5812fe83091a3bc7957bc758e0384e7f5b86fdb6a52bc22`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:f36338f902bd18a95de9b9746303f82715d6a34e1a73bcdf5833d51e5a89d34b`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:5453e207bf7f1f39ee8dca940f1a85c5fb601ac75a8bcc918998da3c4dd13a6a`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:00c3232fd64f1be5e3d2432239561c8def6d5fe4678f4a70a74991bc46580452`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:84926642bc0a306a5a4170adc2152546a734b572a0b90f664e46c1e9d92eac91`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:62a085212e74bd9a8edaf6059311fb77154094b66fe3c455dc00428f06753651`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:1022fa308d15d2c9562dd2696b2b1603f486b4c14aa4c7a68e99a3b54233319f`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:c9133acca365378741337e9176458aac930e11ad046fd2005aa5e77a2b393ddc`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:f1fde22777495a17381daaa3cbb99746769c6e7ed1e84eb02a7928c7d749daa2`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:0a20722c28c606664a41a6655c7fe141bbdde5e8309e31a1e49e5216fa2d18f3`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:46ccf2282bb5681022746c73292dc06b83edd88bfa1fcd5b90e81091e8a03d1d`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:538790f5964fca1d7990d244c6fe7f3f77f035504fbe089606cb4e91de7b9cd1`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:8ad877772abae45070c7880e99adbcb385e158af3f1df39eabcdc1dcc0a39f3c`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:581f099349c2ae56d68970255b3ad6df12a05d69426410588ab5c4a879f938c0`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:878dc78b0064481da33b7adfaa2fa94278eb368d7253bb085f7c6058035296f2`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:150277d2c2c5845f2db54d1976bc97d0efbf5e6638909732e9667448a23385cc`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-vhnrh`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-rnzrt`
- gitsign-v1-3: `gitsign-v1-3-on-push-q7csj`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-bfmj8`
- updatetree-v1-3: `updatetree-v1-3-on-push-td97r`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-hdg6z`
- tuffer-v1-3: `tuffer-v1-3-on-push-754hj`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-mvnmm`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-7kscl`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-mkkt2`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-59q58`
- database-v1-3: `database-v1-3-on-push-q5w4n`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-8dq47`
- logserver-v1-3: `logserver-v1-3-on-push-hmcs9`
- logsigner-v1-3: `logsigner-v1-3-on-push-l9v96`
- redis-v1-3: `redis-v1-3-on-push-w7765`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-wrgxg`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-fhw2n`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-kszj7`

🤖 Generated automatically by one-button-build.sh