### PR TITLE
Update client images from build 2026-05-11

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:0a20722c28c606664a41a6655c7fe141bbdde5e8309e31a1e49e5216fa2d18f3 AS cosign
-FROM quay.io/securesign/gitsign@sha256:f1fde22777495a17381daaa3cbb99746769c6e7ed1e84eb02a7928c7d749daa2 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:8b907797d9b340beeb80c32e54ae65d53c361b957f608e8fffbb723dadc664f9 AS cosign
+FROM quay.io/securesign/gitsign@sha256:54ce44ccc6023141f0e62bfecd12b19202bc9b6224f71ab3fbd1e45e9bfb0ac2 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:150277d2c2c5845f2db54d1976bc97d0efbf5e6638909732e9667448a23385cc as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:ad33da22f6789e112c74cf08801cd090ae70f8a0deebe94eef41158ef3943c33 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:878dc78b0064481da33b7adfaa2fa94278eb368d7253bb085f7c6058035296f2 as rekor
+FROM quay.io/securesign/rekor-cli@sha256:afef9b372151ee6e308760e8bce40a4dc0cd93532a8f9ba4cb2cc49a8b4878c3 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:f36338f902bd18a95de9b9746303f82715d6a34e1a73bcdf5833d51e5a89d34b as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:1022fa308d15d2c9562dd2696b2b1603f486b4c14aa4c7a68e99a3b54233319f as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:20cc7ac24663b3910b10041f07194c5540bff27427e603517519066b9a68bf37 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:69f9eb2ffa26b508bea0b58cec19afd25b26af71a55c563f68883be03dddc957 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:5453e207bf7f1f39ee8dca940f1a85c5fb601ac75a8bcc918998da3c4dd13a6a as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:1818cc733324e9488fc7e24e5ec969955405412d07bfd5336474c2dc98fb1571 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260511-091145-000`
- **tough-v1-3**: `tough-v1-3-20260511-091154-000-j8`
- **create-tree-v1-3**: `create-tree-v1-3-20260511-091154-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260511-091154-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260511-091232-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:5b8a2f831c1ced7226a561602e02f876758a9c20288665165ebbd32d9178cba6`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:7d414e3755678ff7d92d36f40fee8adf9fa64fc81fdb068104eeccd2248d8400`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:f6b5b0a64193e63e3d65e09b802b5071dbd5347f055573ac3d9b941a5635c572`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:09c43773375154b6a672e2e5491dbfcaea0536398fa25a4ca7ecf019113be628`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:20cc7ac24663b3910b10041f07194c5540bff27427e603517519066b9a68bf37`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:1818cc733324e9488fc7e24e5ec969955405412d07bfd5336474c2dc98fb1571`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:d14a63f99e12ae5ac3ecbe61b10d31ad3e0dc89ff45293f9b72e20c561941f23`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:f3797e6540d019e7a089e3fea1d551105afdc7605a3bb0df2c3bfc188c3f5907`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:7b4f3e42b4668795e427b24e51da6e9526a43bf3ffe0717d41123b4a949214b3`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:69f9eb2ffa26b508bea0b58cec19afd25b26af71a55c563f68883be03dddc957`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:7790c84417f93531c9084d25d03dd769a090ebbb32ac937b4f37efd43edd2c84`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:54ce44ccc6023141f0e62bfecd12b19202bc9b6224f71ab3fbd1e45e9bfb0ac2`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:8b907797d9b340beeb80c32e54ae65d53c361b957f608e8fffbb723dadc664f9`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:21cc1b867f93ed7f1e77bb6648fa175d5ddf575212dc2997838372bf138a1696`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:5652d9fff80180e4c440abb208ccc9ad4e51fde62ea93166a66494623898557f`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:86ff53f072e6093614c1e3a89817318a78882fb2e61cf144680a5936c9eb4b23`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:376e266f218cbedbaf3cd99f9b5a1bd44d647589e4af2f4344d40798a55b4f92`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:afef9b372151ee6e308760e8bce40a4dc0cd93532a8f9ba4cb2cc49a8b4878c3`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:ad33da22f6789e112c74cf08801cd090ae70f8a0deebe94eef41158ef3943c33`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-cztqz`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-czlv7`
- gitsign-v1-3: `gitsign-v1-3-on-push-p2s2z`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-nztkj`
- updatetree-v1-3: `updatetree-v1-3-on-push-tqsv4`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-p74l6`
- tuffer-v1-3: `tuffer-v1-3-on-push-xgd6l`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-pzdmv`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-8vz6x`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-zsmvk`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-sjwhp`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-5dhmk`
- database-v1-3: `database-v1-3-on-push-fkcff`
- logserver-v1-3: `logserver-v1-3-on-push-5z9j9`
- logsigner-v1-3: `logsigner-v1-3-on-push-55r29`
- redis-v1-3: `redis-v1-3-on-push-gmr9n`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-x5s66`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-pdp2x`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-l5h69`

🤖 Generated automatically by one-button-build.sh