### PR TITLE
Update client images from build 2026-05-11

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:8b907797d9b340beeb80c32e54ae65d53c361b957f608e8fffbb723dadc664f9 AS cosign
-FROM quay.io/securesign/gitsign@sha256:54ce44ccc6023141f0e62bfecd12b19202bc9b6224f71ab3fbd1e45e9bfb0ac2 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:edd204bbb5f01adb27fef9d3af1815d088eca8c54f17f107dfff418ebae37046 AS cosign
+FROM quay.io/securesign/gitsign@sha256:5c865c4eb97deb8f820b2dedd83427f168173071a2933d5e63a93d07fe8cccbf AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:ad33da22f6789e112c74cf08801cd090ae70f8a0deebe94eef41158ef3943c33 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:8655facb1734a4aef81fc78bebe15991c25271c33968631009e1816c0fed8075 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:afef9b372151ee6e308760e8bce40a4dc0cd93532a8f9ba4cb2cc49a8b4878c3 as rekor
+FROM quay.io/securesign/rekor-cli@sha256:0a7378790f386d9eb1de087cbe997a8ef958121bf38f7fa046de4c8c711f9ffd as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:20cc7ac24663b3910b10041f07194c5540bff27427e603517519066b9a68bf37 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:69f9eb2ffa26b508bea0b58cec19afd25b26af71a55c563f68883be03dddc957 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:f393d65c755b75827eca8ec8edca32e5f44a978b1cc763de47bdfd982db717a4 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:a473437cbb66c2505fb39da335554db758e6997b11d1699875b007ea10821c9f as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:1818cc733324e9488fc7e24e5ec969955405412d07bfd5336474c2dc98fb1571 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:fee31a1cd0eeef89003b38c7b8ed30a36e937ad13bf19cdf72f9cb0506ab67df as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260511-100018-000`
- **tough-v1-3**: `tough-v1-3-20260511-094417-000-cv`
- **create-tree-v1-3**: `create-tree-v1-3-20260511-094419-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260511-094419-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260511-094428-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:ba36c97994cc7a287b3353091f726e45708806ec17d53cd0284cd1974f34459a`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:d110a0944852833cab52636efc608fd7e5d8c983699160bef7bfab37d8307b4f`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:942e7096f4d060668e2d51eb723b4683e6c0bae47d2e5538148945dedac8e4b9`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:1895fb85961e3ec20904595d7248247c8cb2c7e056444c233d49cab1936898a8`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:f393d65c755b75827eca8ec8edca32e5f44a978b1cc763de47bdfd982db717a4`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:fee31a1cd0eeef89003b38c7b8ed30a36e937ad13bf19cdf72f9cb0506ab67df`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:5be37dff762c3c074b5e7e4ae6fd367ff3aa44c6107815756569f3f241179abb`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:c152db35bd8cc4d2f6d0cb66b5f454b166738a89592386eb9498c054678a3500`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:4537d2421bce326907ba86ecc94707db779aad71c8669eff653fbd32dc0161b9`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:a473437cbb66c2505fb39da335554db758e6997b11d1699875b007ea10821c9f`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:68493a40fa59c53ce82aea9e0880ece07fa4541a9929b93a97a418713a01adb1`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:5c865c4eb97deb8f820b2dedd83427f168173071a2933d5e63a93d07fe8cccbf`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:edd204bbb5f01adb27fef9d3af1815d088eca8c54f17f107dfff418ebae37046`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:5224305006812b9f84f8c05607d8f6f893d94c9ea9d8093a733221ea4f9eeb7f`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:2c9bcc8e33e376af95bfec967b2f9dd46ba68338228edcf4f307518247382572`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:db387cc9b7307c844e06830fed83dc1f0847d19b032bbc7c43457c570f7e67dd`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:a9fd93423cb082b14ecddffa2f035256a991ec56d8993848384a748ffb694513`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:0a7378790f386d9eb1de087cbe997a8ef958121bf38f7fa046de4c8c711f9ffd`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:8655facb1734a4aef81fc78bebe15991c25271c33968631009e1816c0fed8075`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-89hct`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-dkdmg`
- gitsign-v1-3: `gitsign-v1-3-on-push-bgf9v`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-wvzr9`
- updatetree-v1-3: `updatetree-v1-3-on-push-7stz4`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-sdmsw`
- tuffer-v1-3: `tuffer-v1-3-on-push-w7vwt`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-gsm8f`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-g9tk9`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-qh848`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-7l7lt`
- database-v1-3: `database-v1-3-on-push-c9s2w`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-gxgqd`
- logserver-v1-3: `logserver-v1-3-on-push-tpjg4`
- logsigner-v1-3: `logsigner-v1-3-on-push-2xgl9`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-zdspq`
- redis-v1-3: `redis-v1-3-on-push-ss9g7`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-227t6`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-k25h2`

🤖 Generated automatically by one-button-build.sh