### PR TITLE
Update client images from build 2026-05-11

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:edd204bbb5f01adb27fef9d3af1815d088eca8c54f17f107dfff418ebae37046 AS cosign
-FROM quay.io/securesign/gitsign@sha256:5c865c4eb97deb8f820b2dedd83427f168173071a2933d5e63a93d07fe8cccbf AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:32847dec99f502fad4cb4b85dcf2b81454dfda6daa60e557712db9739c0c2947 AS cosign
+FROM quay.io/securesign/gitsign@sha256:96ad7b997a5ab9e12ccbfa854e8c11aaf516c2a85f07fc8143132fdf4cb265a0 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:8655facb1734a4aef81fc78bebe15991c25271c33968631009e1816c0fed8075 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:dc30dc0e5399f9e2d79d3195ad3a99263c293db8e400019135eac0570eb859b1 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:0a7378790f386d9eb1de087cbe997a8ef958121bf38f7fa046de4c8c711f9ffd as rekor
+FROM quay.io/securesign/rekor-cli@sha256:500181b983abdf0196ba68fd75f95ea48a0455844998d05dbc90b6fb83f56b6d as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:f393d65c755b75827eca8ec8edca32e5f44a978b1cc763de47bdfd982db717a4 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:a473437cbb66c2505fb39da335554db758e6997b11d1699875b007ea10821c9f as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:3222b6891daef45e60033df4d259014d09db5723985336b847786fd7922b0321 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:8a9d916df034871209e63d5f868565bb4b2cb6c48f4f8933c3094ca544189d07 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:fee31a1cd0eeef89003b38c7b8ed30a36e937ad13bf19cdf72f9cb0506ab67df as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:e7cad4451a49c1cb9cac45a4b8695b00a9c354fe8df798bbaef10bc6031c55ad as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260511-112021-000`
- **tough-v1-3**: `tough-v1-3-20260511-105910-000-zr`
- **create-tree-v1-3**: `create-tree-v1-3-20260511-105923-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260511-105916-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260511-110739-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:7975c56ff99fc471489fa1d08ca4868761f632ac14c0045bfd5c88d9e47b8f69`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:e7a3996ad5fc3b102ec0dfd1dd78f45399db26dbd698e6298cc381b85c781b85`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:aac6b1853fa4e81c8702327900c7853654ac0bb99227a10cdf657ca88b99caf3`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:c1135c76ef313214f8f0efa8373dce60e4d998167051ca4aea8d664a218555d4`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:3222b6891daef45e60033df4d259014d09db5723985336b847786fd7922b0321`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:e7cad4451a49c1cb9cac45a4b8695b00a9c354fe8df798bbaef10bc6031c55ad`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:b245d0ce6849cf3d03dcfbe738b458a20ebf12a11bc0967dd06ec265b1c23c1d`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:2e0b5fb33b5d85e083ef9e976d0ecd56d676f043637a695950320f87247e865d`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:5912a5c6d751324ceec2dfa37313f5bb458d6189afe889311645aa53a49ab3b9`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:8a9d916df034871209e63d5f868565bb4b2cb6c48f4f8933c3094ca544189d07`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:d4afd5d3e1cb79973b1a553dd77eb05e8e9acca2286ba5125d944306d43b9b16`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:96ad7b997a5ab9e12ccbfa854e8c11aaf516c2a85f07fc8143132fdf4cb265a0`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:32847dec99f502fad4cb4b85dcf2b81454dfda6daa60e557712db9739c0c2947`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:0d9097e5fd040383de125e34725930a3cf07f1fe93790a281666e5578cbee45e`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:ed0cda91cf1131fb9ff0b90c3cc77c6406958fba760d86fbe785037b15f3d4b0`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:92b3611c576e3261933fba0f5ddcbd77461d49f7fe819c280dde7c371ff59441`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:b5743d6949b2c3c8295de0adde510b4366fa578150cfc196a2a978bcf8567688`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:500181b983abdf0196ba68fd75f95ea48a0455844998d05dbc90b6fb83f56b6d`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:dc30dc0e5399f9e2d79d3195ad3a99263c293db8e400019135eac0570eb859b1`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-w57xg`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-59z2z`
- gitsign-v1-3: `gitsign-v1-3-on-push-459t4`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-s2s52`
- updatetree-v1-3: `updatetree-v1-3-on-push-rtlhn`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-ht5x5`
- tuffer-v1-3: `tuffer-v1-3-on-push-bjh59`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-5llr5`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-gztq4`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-brfz2`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-zfqzh`
- database-v1-3: `database-v1-3-on-push-lnwzq`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-zjclg`
- logserver-v1-3: `logserver-v1-3-on-push-5x9q5`
- logsigner-v1-3: `logsigner-v1-3-on-push-sm94m`
- redis-v1-3: `redis-v1-3-on-push-pm5kk`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-njqqs`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-nkr6t`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-fgmwf`

🤖 Generated automatically by one-button-build.sh