### PR TITLE
Update client images from build 2026-05-18

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:edd204bbb5f01adb27fef9d3af1815d088eca8c54f17f107dfff418ebae37046 AS cosign
-FROM quay.io/securesign/gitsign@sha256:5c865c4eb97deb8f820b2dedd83427f168173071a2933d5e63a93d07fe8cccbf AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:1760779d511b7f9e132ece2982f21dc6b2abb1d344fe0f9cf78fd81d133a68a4 AS cosign
+FROM quay.io/securesign/gitsign@sha256:1141c3a832129cf5cfdad679827732ba6e3dbf0b24f0e590ac536d1401a8cce2 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:8655facb1734a4aef81fc78bebe15991c25271c33968631009e1816c0fed8075 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:9e3bba3fc465a8a7d8fca5681e02b0b84082b466e44b3569c7f3a604e40c4f4b as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:0a7378790f386d9eb1de087cbe997a8ef958121bf38f7fa046de4c8c711f9ffd as rekor
+FROM quay.io/securesign/rekor-cli@sha256:43af5226959e05789e4c9d24cb881abcb9a128489f6541239e757cde28d6419d as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:f393d65c755b75827eca8ec8edca32e5f44a978b1cc763de47bdfd982db717a4 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:a473437cbb66c2505fb39da335554db758e6997b11d1699875b007ea10821c9f as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:31d3b352a4b2257a8d548ae82ed4793ef82b7a7572657e49bc7ca56a123f58fe as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:18690a576e32f3ffc2fa7d741acf122d04a2c702763c447ec098def98913590f as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:fee31a1cd0eeef89003b38c7b8ed30a36e937ad13bf19cdf72f9cb0506ab67df as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:38b9bb7d7a1f74ec0ed6be2bb9f8e99375d23efa63aa6b84732d8686bdff8ca1 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260518-070925-000`
- **tough-v1-3**: `tough-v1-3-20260518-070929-000-8f`
- **create-tree-v1-3**: `create-tree-v1-3-20260518-070932-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260518-070931-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260518-071653-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:5c725f7700814df6bc1a939eb10a8d282b21af9d650da5eb581b1f87a60c7a8e`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:db297364b2b5f07a019a7736e9e2a717e1e979b2e21b217399a51fcb058d663a`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:ce972f321da7bec7727c19d67c9c0f22e426eaaa556a3f633c0844fd77dd29d2`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:42e464711aaf7d8e1a8003e4d50c290b09ec6631f508dc7a276b567b42e311c8`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:31d3b352a4b2257a8d548ae82ed4793ef82b7a7572657e49bc7ca56a123f58fe`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:38b9bb7d7a1f74ec0ed6be2bb9f8e99375d23efa63aa6b84732d8686bdff8ca1`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:ef5215e8e5f5931dcd563ffca2a4968d3f2fee926e0821beb05e8ffa7dd70926`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:e70d660cd7652c6a0de6170516361886a9597379f781c05ca7c101e3d70b7b61`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:925fbb443d180633cf69499568c1b2e470ecaf428f2aeac32f6eecde7de97e97`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:18690a576e32f3ffc2fa7d741acf122d04a2c702763c447ec098def98913590f`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:5dea4a01c7797106f2670156cf96e297bdead705a8c11fd46ca6b726f7137ce7`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:1141c3a832129cf5cfdad679827732ba6e3dbf0b24f0e590ac536d1401a8cce2`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:1760779d511b7f9e132ece2982f21dc6b2abb1d344fe0f9cf78fd81d133a68a4`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:db0a21b3dff1fcd86819f1905ef25b054ae32a62ec9c84f68b3ed940b427a851`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:4da56b3c7e689605729db88c2a637dfdcb6cb51a810c387811fa9a03799401f8`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:8c3792e307464b8756ac4f17cd1735044346ac7ac74cc845c1193c1c8d6b568d`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:ea5ff529bb8f945d5b9b91f735c02e8b4fc134ee2e3bc57ae78cf9534750637c`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:43af5226959e05789e4c9d24cb881abcb9a128489f6541239e757cde28d6419d`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:9e3bba3fc465a8a7d8fca5681e02b0b84082b466e44b3569c7f3a604e40c4f4b`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-l6wfm`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-njpfl`
- gitsign-v1-3: `gitsign-v1-3-on-push-ggng8`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-gz2hg`
- updatetree-v1-3: `updatetree-v1-3-on-push-z7gnw`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-b5948`
- tuffer-v1-3: `tuffer-v1-3-on-push-476n7`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-nnfr7`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-qzptc`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-nlsc8`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-mgbr9`
- database-v1-3: `database-v1-3-on-push-6m75x`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-7nh5b`
- logserver-v1-3: `logserver-v1-3-on-push-592ns`
- logsigner-v1-3: `logsigner-v1-3-on-push-x8x2q`
- redis-v1-3: `redis-v1-3-on-push-pvzl7`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-4svn9`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-8jlb5`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-9hhjc`

🤖 Generated automatically by one-button-build.sh