### PR TITLE
Update client images from build 2026-05-18

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:1760779d511b7f9e132ece2982f21dc6b2abb1d344fe0f9cf78fd81d133a68a4 AS cosign
-FROM quay.io/securesign/gitsign@sha256:1141c3a832129cf5cfdad679827732ba6e3dbf0b24f0e590ac536d1401a8cce2 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:8d35d30d2d1631a0d3b9563518d0a27f5bf7e823d079b4744bc35bc5c9167500 AS cosign
+FROM quay.io/securesign/gitsign@sha256:e6ea4298567ccf126feaf8f78d044eb2af20aab16ad8d47a770ffd4da719eca2 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:9e3bba3fc465a8a7d8fca5681e02b0b84082b466e44b3569c7f3a604e40c4f4b as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:290dac48956876827ad6b367940b2e4ed56a55ecc8336ba8e0736e2084d5d66e as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:43af5226959e05789e4c9d24cb881abcb9a128489f6541239e757cde28d6419d as rekor
+FROM quay.io/securesign/rekor-cli@sha256:4e283be941a9ae9f281601111fc3deb0abdb1558bca1437d6dd6517163db7b96 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:31d3b352a4b2257a8d548ae82ed4793ef82b7a7572657e49bc7ca56a123f58fe as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:18690a576e32f3ffc2fa7d741acf122d04a2c702763c447ec098def98913590f as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:ff99e5e263dffcfcd613f6a3bfc0ec337c661b40a56a362c85295cdb1f2232bf as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:6e2c057c7c3ca27179d86b1ec364131f06365acf5c0342c0c060a47ea027984f as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:38b9bb7d7a1f74ec0ed6be2bb9f8e99375d23efa63aa6b84732d8686bdff8ca1 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:b77b0d9efd574ee570f4320ec331503b8dc1a0bbf59413297684cbf875c2c48b as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260518-074608-000`
- **tough-v1-3**: `tough-v1-3-20260518-074614-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260518-074616-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260518-074615-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260518-074623-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:d67bd8a3b40ee55694ec309b8f1072525c02d2d005de17518dbd55b9022a2eb2`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:45577624de554c1fc0c28599668dae42b24aa47aac96bc305571970a35bdb1bc`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:8a1f34f3a9c56b3fff0a550c3ed859f72547b138aa7bc7f42b83987f30e2cd84`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:a7e8369436eb831da0124d2f477f79f8a9844b9998b80ff912b3630670717b27`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:ff99e5e263dffcfcd613f6a3bfc0ec337c661b40a56a362c85295cdb1f2232bf`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:b77b0d9efd574ee570f4320ec331503b8dc1a0bbf59413297684cbf875c2c48b`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:d8369140c81422b8e7bbf96c17a082a3399d1dad8dd73cd7d97b4bc3172690e3`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:c6fbe59d3f10a3334724aa636ad4b770aadc7210c7a4be5125cf81b8ce53678a`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:0889e8736de7b7c43e688d1199d64fc3129f7b9e3bd5f5b8c431800e05ba001e`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:6e2c057c7c3ca27179d86b1ec364131f06365acf5c0342c0c060a47ea027984f`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:9d12765576adcef0ef87045b6ccb483d08169c8dd4cdb5e71c5c6abc1439d767`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:e6ea4298567ccf126feaf8f78d044eb2af20aab16ad8d47a770ffd4da719eca2`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:8d35d30d2d1631a0d3b9563518d0a27f5bf7e823d079b4744bc35bc5c9167500`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:506a14c421fb06421203ec75157a900ec22ba1c72af8cf2928999f7c253df43a`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:006fefddb5789a813c7ee350b8649d66c9e3e09d6b4620bbf04e1810bd9e8d73`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:8a3c92223932fbc2dc555f2846dc23d4be342f6d12674a7118b04e1faa43ea85`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:c491c0f4f17a77cf806ea3e222f16e76a23b3afa911a07631d12175cb1748195`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:4e283be941a9ae9f281601111fc3deb0abdb1558bca1437d6dd6517163db7b96`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:290dac48956876827ad6b367940b2e4ed56a55ecc8336ba8e0736e2084d5d66e`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-l9rdb`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-6zc6p`
- gitsign-v1-3: `gitsign-v1-3-on-push-c4tgk`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-fc2qc`
- updatetree-v1-3: `updatetree-v1-3-on-push-fnh5v`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-bjvwg`
- tuffer-v1-3: `tuffer-v1-3-on-push-stll8`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-j96dw`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-l6j68`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-l6fb9`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-7xwn5`
- database-v1-3: `database-v1-3-on-push-52gvl`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-dw8c7`
- logserver-v1-3: `logserver-v1-3-on-push-74jgf`
- logsigner-v1-3: `logsigner-v1-3-on-push-dqv54`
- redis-v1-3: `redis-v1-3-on-push-r59c7`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-j2g8t`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-6nxhq`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-sbh6d`

🤖 Generated automatically by one-button-build.sh