### PR TITLE
Update client images from build 2026-05-18

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:8d35d30d2d1631a0d3b9563518d0a27f5bf7e823d079b4744bc35bc5c9167500 AS cosign
-FROM quay.io/securesign/gitsign@sha256:e6ea4298567ccf126feaf8f78d044eb2af20aab16ad8d47a770ffd4da719eca2 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:a9f7b24630e0e8a03355ef19e04414a73bbcf1e433862d14f4e418524afef056 AS cosign
+FROM quay.io/securesign/gitsign@sha256:ae01f634a70c889a7864a57101b613cac2d6d23a2af46a7ec4250128550d3ca8 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:290dac48956876827ad6b367940b2e4ed56a55ecc8336ba8e0736e2084d5d66e as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:f6bb09d074589df8c840f4ba1c735f56c5e91f36448780b9ecf3de9f5f9ea498 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:4e283be941a9ae9f281601111fc3deb0abdb1558bca1437d6dd6517163db7b96 as rekor
+FROM quay.io/securesign/rekor-cli@sha256:5b2f42583324375be4c885cd1e2055dbc2b40d326cd24e69b0367e3cdb52b611 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:ff99e5e263dffcfcd613f6a3bfc0ec337c661b40a56a362c85295cdb1f2232bf as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:6e2c057c7c3ca27179d86b1ec364131f06365acf5c0342c0c060a47ea027984f as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:dc9240c23d8e224ec986e4773b1f889759ee6119968cf8ea1262455c864bcfa4 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:c398d693746c9a909a9dcc00509d4cb5c6dfdb7dbcbdcedffc94a71406c1f887 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:b77b0d9efd574ee570f4320ec331503b8dc1a0bbf59413297684cbf875c2c48b as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:ba47fd27a7e8afa9c48ac2727e09c43960a9be183a359e5e2146e25732b8883d as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260518-084729-000`
- **tough-v1-3**: `tough-v1-3-20260518-085051-000-zo`
- **create-tree-v1-3**: `create-tree-v1-3-20260518-085058-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260518-085053-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260518-085128-000-eh`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:9e2abd1d5b4c48c023691fb01cd0f67fc9ab6d7ce072dd69ab623a858caab79f`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:590eaab1652759418ec216a2b542e1515b22234bc46b9ea35046c9fe010c5484`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:e9826122b635a878e54a4667ea82fea1d19088aed4fb9a7f03539890736592e6`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:d9eddf55ea2cbd4dd41ae693e99f28dce2c5c9cdbf5fb76859ce60c0b73fe880`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:dc9240c23d8e224ec986e4773b1f889759ee6119968cf8ea1262455c864bcfa4`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:ba47fd27a7e8afa9c48ac2727e09c43960a9be183a359e5e2146e25732b8883d`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:0479098a2536db35a5bdb86633f929397fb6865eeaef4cbe0a3961ec571629fc`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:d4488592da2bbbfae2b6a8acb2fc2552928066964270736fcf48c54863af876b`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:4584a08866b3bd23021d5ddaee09c40b17ccaf02422731cd96fa4f7fc30ca4fb`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:c398d693746c9a909a9dcc00509d4cb5c6dfdb7dbcbdcedffc94a71406c1f887`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:adc55e45c7ac17d4ece9b4b5244e5bc1e080fbbbc7bafda4162b60f642d6629b`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:ae01f634a70c889a7864a57101b613cac2d6d23a2af46a7ec4250128550d3ca8`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:a9f7b24630e0e8a03355ef19e04414a73bbcf1e433862d14f4e418524afef056`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:f35b07a4699d470044ed6bf3d7715a6b10950262d509cd75e7a1507edff7fa99`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:021040fc1a33efd56e4e90990c194484ae68dae5416029eb034bf60f547a1108`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:85e40dfc1b0370b9d963e3c96d91d1d8d429fc42607c75b471190debf40bfdf7`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:94fc90416409d23607508e4055fe787d5470e3cc115239fbeac869910a626d6d`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:5b2f42583324375be4c885cd1e2055dbc2b40d326cd24e69b0367e3cdb52b611`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:f6bb09d074589df8c840f4ba1c735f56c5e91f36448780b9ecf3de9f5f9ea498`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-vkfpw`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-mb47w`
- gitsign-v1-3: `gitsign-v1-3-on-push-n6qgc`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-fg67h`
- updatetree-v1-3: `updatetree-v1-3-on-push-kk8bj`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-bwq9n`
- tuffer-v1-3: `tuffer-v1-3-on-push-5jf6w`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-w6b95`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-b8wn4`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-dk4pf`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-h9gtk`
- database-v1-3: `database-v1-3-on-push-gtktx`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-gm4zf`
- logserver-v1-3: `logserver-v1-3-on-push-vf8rm`
- logsigner-v1-3: `logsigner-v1-3-on-push-n8j7d`
- redis-v1-3: `redis-v1-3-on-push-vhvbc`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-2lpxw`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-bw8ww`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-xms58`

🤖 Generated automatically by one-button-build.sh