### PR TITLE
Update client images from build 2026-05-18

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:a9f7b24630e0e8a03355ef19e04414a73bbcf1e433862d14f4e418524afef056 AS cosign
-FROM quay.io/securesign/gitsign@sha256:ae01f634a70c889a7864a57101b613cac2d6d23a2af46a7ec4250128550d3ca8 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:536fdb3d43093893c94769bbfdace979f542ff75dabf1af8c043203f47026fbe AS cosign
+FROM quay.io/securesign/gitsign@sha256:b368465fdb6cff0deb83adab73b844b0d11d81d401dfdca5d9a9c22bed01ae44 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:f6bb09d074589df8c840f4ba1c735f56c5e91f36448780b9ecf3de9f5f9ea498 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:437b10cf6e357e417630281d33048d0ab189efdfc21f9fe3f0d0a798e70117ff as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:5b2f42583324375be4c885cd1e2055dbc2b40d326cd24e69b0367e3cdb52b611 as rekor
+FROM quay.io/securesign/rekor-cli@sha256:9dfb332d8b1b4cd9bb4db06541744a0e1e1ff9b863ad4681d257a21a3ad6eddd as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:dc9240c23d8e224ec986e4773b1f889759ee6119968cf8ea1262455c864bcfa4 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:c398d693746c9a909a9dcc00509d4cb5c6dfdb7dbcbdcedffc94a71406c1f887 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:12f7f58283a482e8a4c9ccb219afa8f29a536461e43b0a1cf82ece5f6d355e9a as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:250d3214afcc3859b219dbc668645ccb2e7f5fdeb27e36b2faf62912feb9bfe3 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:ba47fd27a7e8afa9c48ac2727e09c43960a9be183a359e5e2146e25732b8883d as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:86f778fc8a35c0f7dcccc0964af15d25de85cb27d14c4978befac98041a0e318 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260518-095123-000`
- **tough-v1-3**: `tough-v1-3-20260518-095142-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260518-095252-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260518-095148-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260518-095400-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:c28f2583f0217059e4e43416d8469da4b0d44dfa83c3f2d342eeb98aaa5164aa`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:adbaba6974a20ad7dc7497e2182f345bc1f17d9889ee8af34ea7222ff89b5d43`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:725d05ec0a7b301a859cdf64ca6d67d481b5700c876c1de2b16aa78a315df288`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:6f2517a0c27e0f42585f6b427e748c72d420f5cf8588b1cf7e8c2638c3e67442`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:12f7f58283a482e8a4c9ccb219afa8f29a536461e43b0a1cf82ece5f6d355e9a`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:86f778fc8a35c0f7dcccc0964af15d25de85cb27d14c4978befac98041a0e318`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:a2447ecda5f4ddb6a1dee125cccd93278643e99118ea6a6c17e384c45d44141d`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:2b4ea658ffcf68e194be92133a1c2d3de27662f518a6238fc1d6956aec9bc820`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:7aeb7c5c3c24d008d50811bc71797f54a1428cdab273f116a74b816954cf2286`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:250d3214afcc3859b219dbc668645ccb2e7f5fdeb27e36b2faf62912feb9bfe3`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:18e0e3ba0834a03c4b431355d48f1dd5cd0728e30d0294c3c50ce95d34ca64bf`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:b368465fdb6cff0deb83adab73b844b0d11d81d401dfdca5d9a9c22bed01ae44`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:536fdb3d43093893c94769bbfdace979f542ff75dabf1af8c043203f47026fbe`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:49f80e8e1373466ffebd760539ab3751400e150dc913e8d538540154843d0e93`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:e6918232c4e59187d27d89e7fad33b6b665e3bd545432f95ce4b2236d1024557`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:178ef51e29872e1d1aed7a075e0fb4c818371cd0e4abd0220bc915ade2f610e7`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:2a6b83b8125b855e28ab5a4306927a33bb861207b5ba2a17fea459132234ac38`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:9dfb332d8b1b4cd9bb4db06541744a0e1e1ff9b863ad4681d257a21a3ad6eddd`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:437b10cf6e357e417630281d33048d0ab189efdfc21f9fe3f0d0a798e70117ff`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-k8kx7`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-d7k4p`
- gitsign-v1-3: `gitsign-v1-3-on-push-fcrc7`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-89hpn`
- updatetree-v1-3: `updatetree-v1-3-on-push-mzsxj`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-nwrcz`
- tuffer-v1-3: `tuffer-v1-3-on-push-s6k8d`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-zkdvg`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-nr6nr`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-6njbg`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-n727w`
- database-v1-3: `database-v1-3-on-push-snf5v`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-8v9tq`
- logserver-v1-3: `logserver-v1-3-on-push-k2vjq`
- logsigner-v1-3: `logsigner-v1-3-on-push-gvplh`
- redis-v1-3: `redis-v1-3-on-push-bsq8d`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-6xmcf`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-868lr`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-bxsxq`

🤖 Generated automatically by one-button-build.sh