### PR TITLE
Update client images from build 2026-05-18

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:536fdb3d43093893c94769bbfdace979f542ff75dabf1af8c043203f47026fbe AS cosign
-FROM quay.io/securesign/gitsign@sha256:b368465fdb6cff0deb83adab73b844b0d11d81d401dfdca5d9a9c22bed01ae44 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:329895a76a6dbdc20d2f62186fad8ddfb85be24801a319b10db69e4037c00121 AS cosign
+FROM quay.io/securesign/gitsign@sha256:f627f17af4c30c6888eca21c414e980fcbcb5b8ab1531d8a6727a85f0045474d AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:437b10cf6e357e417630281d33048d0ab189efdfc21f9fe3f0d0a798e70117ff as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:ed75504f268e3daa83d89ef7e624cf02fa47b133ccbf298e1e0be09fc076f5bf as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:9dfb332d8b1b4cd9bb4db06541744a0e1e1ff9b863ad4681d257a21a3ad6eddd as rekor
+FROM quay.io/securesign/rekor-cli@sha256:f23f930067bd07aadebad190bae7a4e46cd51f87453af2bfa1178beb83c6ce62 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:12f7f58283a482e8a4c9ccb219afa8f29a536461e43b0a1cf82ece5f6d355e9a as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:250d3214afcc3859b219dbc668645ccb2e7f5fdeb27e36b2faf62912feb9bfe3 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:cfb85006207e79aaeaa298406b142c43197b7091396b88b3022f3b4268ef6806 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:378d70fc5336e990b66d85d2dbadb605ac95cc1644ecda3a09287bdbc956e527 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:86f778fc8a35c0f7dcccc0964af15d25de85cb27d14c4978befac98041a0e318 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:8ddafda3ca282acf2837320f269938370e05f277b2e120a2e8b603820a66b67d as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260518-104333-000`
- **tough-v1-3**: `tough-v1-3-20260518-104339-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260518-104347-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260518-104344-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260518-104410-000`
- **rekor-monitor-v1-3**: `rekor-monitor-v1-3-20260518-104424-000`

### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:66a47d0b7d85d460a8589e8f6dad9cc673ec8c8590c73b8d4a3af053afc33554`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:7f52fc2ad2b1698a748294c6a497285c7b7720ea0d8882c7f546aac7525c2cfa`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:6c2cde3853c4c8c669eeb784f847c3e6cb4f0c7cccaa41302dbf017408c9c7e6`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:2884191173a54f6237dfb2f4564b7da7eb34c569fc001d2e7a6b239aa5ae4cbb`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:cfb85006207e79aaeaa298406b142c43197b7091396b88b3022f3b4268ef6806`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:8ddafda3ca282acf2837320f269938370e05f277b2e120a2e8b603820a66b67d`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:fcac0cd4df1350c161a3d9b1ed37182c381946b1783ef8a4787891109dc1139d`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:a174148c79288175edf9bbb4c52f2b0b275c02aa34c4c297debe6d00bcddac9c`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:da69dba3f36dc801fd18f633e9d957cd6eb760d1f6fd43c0d86cf4c1443e636a`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:378d70fc5336e990b66d85d2dbadb605ac95cc1644ecda3a09287bdbc956e527`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:af2d6b2deae2591d358227174afeb7e02ff511d8728b6e32bb5db460827c9742`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:f627f17af4c30c6888eca21c414e980fcbcb5b8ab1531d8a6727a85f0045474d`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:329895a76a6dbdc20d2f62186fad8ddfb85be24801a319b10db69e4037c00121`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:6b71c3a52d6fd50ef08fbad72a3511bd3e5f432ff338f0897e9e0d5d16b5e744`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:86a6f4b36e098a9b22c8f1f3ae39e6befe08028da610fe11cc5c0a3e1b0f6592`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:7211a3e9dbafb9974cb499e68d38df863d371823a7b3da3ef848e6d9c445cd30`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:349b8dc8ab211ee134f533c0888e82261790aed1124eb1a9c97b8e9e45edc06a`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:f23f930067bd07aadebad190bae7a4e46cd51f87453af2bfa1178beb83c6ce62`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:ed75504f268e3daa83d89ef7e624cf02fa47b133ccbf298e1e0be09fc076f5bf`
- **rekor-monitor-v1-3**: `quay.io/securesign/rekor-monitor@sha256:2140c12528c9cf6db610edeec7c9cd2c41779e3d01de5adef5a7c587ef4164d0`

### Pipeline Runs
#### tas-tools-v1-3
- cosign-v1-3: `cosign-v1-3-on-push-mv2kt`
- fetch-tsa-certs-v1-3: `fetch-tsa-certs-v1-3-on-push-jdzsq`
- gitsign-v1-3: `gitsign-v1-3-on-push-7xqtn`
- rekor-cli-v1-3: `rekor-cli-v1-3-on-push-65wkq`
- updatetree-v1-3: `updatetree-v1-3-on-push-mp7wv`
#### tough-v1-3
- tuf-tool-v1-3: `tuf-tool-v1-3-on-push-bjtwz`
- tuffer-v1-3: `tuffer-v1-3-on-push-gf66n`
#### create-tree-v1-3
- create-tree-v1-3: `create-tree-v1-3-on-push-hrxlg`
#### segment-backup-job-v1-3
- segment-backup-job-v1-3: `segment-backup-job-v1-3-on-push-7nb6l`
#### tas-components-v1-3
- backfill-redis-v1-3: `backfill-redis-v1-3-on-push-gr8t6`
- certificate-transparency-go-v1-3: `certificate-transparency-go-v1-3-on-push-nqphb`
- database-v1-3: `database-v1-3-on-push-t9cj8`
- fulcio-server-v1-3: `fulcio-server-v1-3-on-push-9kmvl`
- logserver-v1-3: `logserver-v1-3-on-push-sfz6s`
- logsigner-v1-3: `logsigner-v1-3-on-push-tt8t4`
- redis-v1-3: `redis-v1-3-on-push-jv4hg`
- rekor-search-v1-3: `rekor-search-v1-3-on-push-4tld5`
- rekor-server-v1-3: `rekor-server-v1-3-on-push-57wj4`
- timestamp-authority-v1-3: `timestamp-authority-v1-3-on-push-f9pxb`
#### rekor-monitor-v1-3
- rekor-monitor-v1-3: `rekor-monitor-v1-3-on-push-bnxtm`

🤖 Generated automatically by one-button-build.sh