### PR TITLE
Update client images from build 2026-05-27

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:07f1d5d0cadb44691f3f61978a9b4d88e329683ab73fec985f122f312933dbe0 AS cosign
-FROM quay.io/securesign/gitsign@sha256:a6681cf50c03f7de6eed5780298693e254d7bf0345664497df98bccbbcf2fdd7 AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:df6e79f4c77f44ded8afe3bc83dc629d4e444f2f2c5d8167a40a1ef9a48081aa AS cosign
+FROM quay.io/securesign/gitsign@sha256:cfa2b79b6f0e473da7cc2a294f1e2b963f389338b9df1f3b789e5aa329429c90 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:079492c7192b0c2f11aee50951c23dfac74efb3198ff1b9f1e95fa549fad3d93 as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:ea876791aa4e07198d5ddf82f344fcb3e8d1f127129f5b9aae54206059aeefd3 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:79d23e5730aec0e80d006234d8c162121e7e580798116f72e53e9f5c9387a28f as rekor
+FROM quay.io/securesign/rekor-cli@sha256:16cc0cfe833fe5593fe69374c985c200ce22df52efaff8353cca11fe6dc4432b as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:a5055fdbc882ed7e2c7fe3e4b6ff239907180f4cd97d428745d5549a448f9fe8 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:e16e50bd9ec23fcd62360bec5b5a99f487b4eab513ac8f19d6f1e6ab3bb035dc as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:0d33d8465a8a6d6e280fdb8f570f7d3b53e1873699bfb91f8d130bfd792a6182 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:26e7b8525360367221644a352c5e9891a8de20cc4031d818cab24618c80e464b as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:3abaa15510b517f3b8258c33c94c4b52b927cc61845b37f0985276947ddda887 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:d4bda832e00932a5cc052a5e36c562fb3225238632706311efd64895cebbcca0 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **create-tree-v1-3**: `create-tree-v1-3-20260527-072911-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260527-072907-000`
- **rekor-monitor-v1-3**: `rekor-monitor-v1-3-20260527-072903-000`
- **tas-tools-v1-3**: `tas-tools-v1-3-20260527-072911-000`
- **tough-v1-3**: `tough-v1-3-20260527-072904-000-x2`

### Updated Images
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:768c4bb6f32ea8db7ef2700272ed00069c93a70ee18b703a70e3925aaf161dd2`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:da2f9ed3bed64b76a322aa5c48d0eee54733ac93b992bd731c65a4cce212ca67`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:ea876791aa4e07198d5ddf82f344fcb3e8d1f127129f5b9aae54206059aeefd3`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:cfa2b79b6f0e473da7cc2a294f1e2b963f389338b9df1f3b789e5aa329429c90`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:e5a34435aeacbaacef422c96aa0e27d503e12a8aae0929b3a57fb9a5a09bae33`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:df6e79f4c77f44ded8afe3bc83dc629d4e444f2f2c5d8167a40a1ef9a48081aa`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:16cc0cfe833fe5593fe69374c985c200ce22df52efaff8353cca11fe6dc4432b`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:26e7b8525360367221644a352c5e9891a8de20cc4031d818cab24618c80e464b`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:05cdfdc51993aa785fef05b70d6e9152b2d585dfff547f8c29b4fa5ccba3e5cc`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:5f5e88560db326ecbbb27916a70758266dd8eeb9287c246713298dd6e71c92ea`
- **rekor-monitor-v1-3**: `quay.io/securesign/rekor-monitor@sha256:c5e7d01e3010051bdaf7c272233c5cb67061966c3a13e3ccd54af13956f6d678`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:3a171e0a90390803fef73f3d94336210277cf91abb6874ec14db62e1f93a3bb6`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:0d33d8465a8a6d6e280fdb8f570f7d3b53e1873699bfb91f8d130bfd792a6182`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:c9516ddd056785898a9fa3b5e549188fcd57e408ccd5aae060c480b3dccfbc22`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:359eee136cf46aaa02a99809c1865e389111de9218df7db51ac8257dbf3a97d5`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:d8456b3c9dc6217afd6b7a61c6f3c8521e061f79531ae000211029a3ab452ea8`
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:4823b2a940b8f94891297fead73cd7987ab910e5daeda5aafd7c968e047187c9`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:d4bda832e00932a5cc052a5e36c562fb3225238632706311efd64895cebbcca0`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:b206506adf3e8b28883f4a139754e2fbd425ff233cc199b8ce8b8558d323ed30`

🤖 Generated automatically by one-button-build