### PR TITLE
Update client images from build 2026-05-27

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -10,10 +10,10 @@ FROM quay.io/securesign/rekor-cli@sha256:5e23e74f11fb0f18d7a97ba6c33a74bb603b679
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:9dcc6e0ebb0e7820b51fae9d766f5e8ced741ef952d1b87a60bffe25560c2200 as trillian-createtree
+FROM quay.io/securesign/trillian-createtree@sha256:2d8cfb2c80115836b156051c51955a8cbd6fbcf722ef026383cd3a6e14440c01 as trillian-createtree
 FROM quay.io/securesign/trillian-updatetree@sha256:76316ad64bfd56fbf2414d85564043976d1747134ab38d9304cc37d8e3e3e949 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:8b74f3ac9dbfa5b583a37890d9e785358a42dc5de02f17f1d9f755bd3037caaa as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:b03eb9f81ca709869e34d2184210de04f1508680b4f8eb9422f9f95d2dfe0454 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-components-v1-3**: `tas-components-v1-3-20260527-094706-000`
- **rekor-monitor-v1-3**: `rekor-monitor-v1-3-20260527-094707-000`
- **tas-tools-v1-3**: `tas-tools-v1-3-20260527-085137-000-bi`
- **tough-v1-3**: `tough-v1-3-20260527-094701-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260527-094709-000`

### Updated Images
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:2d4497b2165e9dbf7ed653ea4258b81782405b3ef9b1c3030f371b6d7c12d84e`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:d09d7ce5ee1438a254ab7f5dcb9d8cdf064166dd7a9d3ad712db480aa4a260aa`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:8608dc5542f7d9f7d828881250579f5e287e9e8bc924d64e06cb2674de8d36bd`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:daf576d839cb3df381df061c1b0532aaf536e43ed40e014f02c96f6ea088f242`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:97e58fccd4190512833540b436cc9933dc7a718f27c79d6ed8435e11fd4c2e46`
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:c127693dc42280bd588c4161427ebcaa266629ea11a5d9ba37fe52857da3e091`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:5e23e74f11fb0f18d7a97ba6c33a74bb603b67981a16e9cc8288eb7e0e45e31e`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:2d8cfb2c80115836b156051c51955a8cbd6fbcf722ef026383cd3a6e14440c01`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:22f07dc33d4e566114177d42e046b78c429d57c3e8748be492a1aab576ea1e4f`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:5b21497f0a9dc050204a133daaa19dd4c3f33a9432bf5dcabdc96211a3b435e1`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:76316ad64bfd56fbf2414d85564043976d1747134ab38d9304cc37d8e3e3e949`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:b03eb9f81ca709869e34d2184210de04f1508680b4f8eb9422f9f95d2dfe0454`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:273e5ce8bfb52690d394095112d6f4291493aeed31c5a0b7cdcd5d4b78529974`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:2f9db6a349399ae40bb8a7ad211bdbc9926384416f359e87f5294f518f244c5e`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:5be9b920cc78d4cb2e67d9343bc7855aa498ac534f93a60c772f59a602f861ba`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:61eb723fbf37c7c64acf7ad90da94cdb0f1c9f56f5993e3da75bd2858704e495`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:5dde821d0ab24692cb55e69514ca96cbdfc9e794c51f760396a3754e11fc26d4`
- **rekor-monitor-v1-3**: `quay.io/securesign/rekor-monitor@sha256:d7b05aaa8676179bf3811d61a329101a2b7a1bd06d146c24014409e57ec21a20`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:7cd63376530d74b0192a3d325a106579fe11ba8034080c060501fb2e24bf93f8`

🤖 Generated automatically by one-button-build