### PR TITLE
Update client images from build 2026-05-27

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,19 +1,19 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM quay.io/securesign/cli-cosign@sha256:7cd63376530d74b0192a3d325a106579fe11ba8034080c060501fb2e24bf93f8 AS cosign
-FROM quay.io/securesign/gitsign@sha256:8608dc5542f7d9f7d828881250579f5e287e9e8bc924d64e06cb2674de8d36bd AS gitsign
+FROM quay.io/securesign/cli-cosign@sha256:070d379aef356b0e32a54cf6a9d1fbf606721f436c4464f1d20b6b0f1f15d3bb AS cosign
+FROM quay.io/securesign/gitsign@sha256:64799db951d7e3aafe6d40782f8f62c6ffb32001e580d49ef150908309241d56 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:2f9db6a349399ae40bb8a7ad211bdbc9926384416f359e87f5294f518f244c5e as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:0c7c4c15efbe05eea44e47c1d20f5fe6337578d85d7f108177cbecf54498f45e as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM quay.io/securesign/rekor-cli@sha256:5e23e74f11fb0f18d7a97ba6c33a74bb603b67981a16e9cc8288eb7e0e45e31e as rekor
+FROM quay.io/securesign/rekor-cli@sha256:c583b047dc18d3cf8afe01ae369d7777954c1e6a396bc0cae370dea9e534eb20 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:2d8cfb2c80115836b156051c51955a8cbd6fbcf722ef026383cd3a6e14440c01 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:76316ad64bfd56fbf2414d85564043976d1747134ab38d9304cc37d8e3e3e949 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:1ec74533332619a59c52ad952531bf8b5cda5d06b467cecc6d778e7a2572f019 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:155d32ac2fb0f1269d799bf243c70e69ba9ee8adf5674ee89d1344d06eb2bf91 as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:b03eb9f81ca709869e34d2184210de04f1508680b4f8eb9422f9f95d2dfe0454 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:1915b512ab642f420e28ab6155fd4abd3fbb85a26b169c6a2ef978310a790397 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tas-tools-v1-3**: `tas-tools-v1-3-20260527-103451-000`
- **tough-v1-3**: `tough-v1-3-20260527-103510-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260527-103956-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260527-103415-000`
- **rekor-monitor-v1-3**: `rekor-monitor-v1-3-20260527-103511-000`

### Updated Images
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:64799db951d7e3aafe6d40782f8f62c6ffb32001e580d49ef150908309241d56`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:1ec74533332619a59c52ad952531bf8b5cda5d06b467cecc6d778e7a2572f019`
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:53a90af32a452951e2679119bb50122adaab363b85da9943db09c32675a6a562`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:fb35727109ed645fe6e369092ccb3ec69f805cf9d630877112b16941da7b6af8`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:5b6127866ecd85751f615cc5bd42f149c7a061cf4c159ce8d9576449a0daaef1`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:4e8300cea9941be7273942339586d7529bbabeed7aa32a9f30602532f3c6c324`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:fa8b0f9b7830fe0f6cb812e4d249f703f7e21c0d8342180627004b57ce2285df`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:de6e1a74dc864b6b9673b65e1c3da07f66180c524337daaaf183c5e0bde5bdad`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:b4d2d182a4e13b1d73792202cdc70f359d302adec72cd4da326d37a2841dbcfd`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:273e5ce8bfb52690d394095112d6f4291493aeed31c5a0b7cdcd5d4b78529974`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:e179309a550f4b955523d99d23e3ec43e22187a05e67403335b535b5f093f20f`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:c583b047dc18d3cf8afe01ae369d7777954c1e6a396bc0cae370dea9e534eb20`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:155d32ac2fb0f1269d799bf243c70e69ba9ee8adf5674ee89d1344d06eb2bf91`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:1915b512ab642f420e28ab6155fd4abd3fbb85a26b169c6a2ef978310a790397`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:bc4d29eafd0170aab3f70644f626e0a93574a940bb8475dddea053715fb502f5`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:53fa52a69af893fbd4421eaa3ff76377b7fe3969f7274615efbe7f76f3710ff2`
- **rekor-monitor-v1-3**: `quay.io/securesign/rekor-monitor@sha256:6fdb7e7df7928117133d6ac36be1f3b2e2f152a85e00442a36e144dae9a27071`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:070d379aef356b0e32a54cf6a9d1fbf606721f436c4464f1d20b6b0f1f15d3bb`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:0c7c4c15efbe05eea44e47c1d20f5fe6337578d85d7f108177cbecf54498f45e`

🤖 Generated automatically by one-button-build