### PR TITLE
Update client images from build 2026-05-27

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -3,17 +3,17 @@ FROM quay.io/securesign/cli-cosign@sha256:070d379aef356b0e32a54cf6a9d1fbf606721f
 FROM quay.io/securesign/gitsign@sha256:64799db951d7e3aafe6d40782f8f62c6ffb32001e580d49ef150908309241d56 AS gitsign
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM quay.io/securesign/fetch-tsa-certs@sha256:0c7c4c15efbe05eea44e47c1d20f5fe6337578d85d7f108177cbecf54498f45e as fetch_tsa_certs
+FROM quay.io/securesign/fetch-tsa-certs@sha256:c79f64d2d1adbc06fe2b2d2d07f4bb82f9fc2fd2222fffb6d93d694c4306f6c9 as fetch_tsa_certs
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
 FROM quay.io/securesign/rekor-cli@sha256:c583b047dc18d3cf8afe01ae369d7777954c1e6a396bc0cae370dea9e534eb20 as rekor
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776366841@sha256:e4dafcf2793e5bd050aff6d458bb161aa9c018f8df43a0142a8b1d6eaea78c9a as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM quay.io/securesign/trillian-createtree@sha256:1ec74533332619a59c52ad952531bf8b5cda5d06b467cecc6d778e7a2572f019 as trillian-createtree
-FROM quay.io/securesign/trillian-updatetree@sha256:155d32ac2fb0f1269d799bf243c70e69ba9ee8adf5674ee89d1344d06eb2bf91 as trillian-updatetree
+FROM quay.io/securesign/trillian-createtree@sha256:59fbc05f2572a54b402349ed0c70f91c01c81775202ce16009a34727d12afa03 as trillian-createtree
+FROM quay.io/securesign/trillian-updatetree@sha256:4eebe34b0d845edb88b4841f2d3846ebd2034fc2a5a65971db01b52919eeee5f as trillian-updatetree
 
-FROM quay.io/securesign/cli-tuftool@sha256:1915b512ab642f420e28ab6155fd4abd3fbb85a26b169c6a2ef978310a790397 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:e11f202c7ccf06fada3e56c76183950f0efd2e044dfc4534cdedd664dba06618 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:06a9ae77db5dd740511ca4dd14f53c245852ba500676869f0e38088b3ab580df
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **tough-v1-3**: `tough-v1-3-20260527-131817-000`
- **create-tree-v1-3**: `create-tree-v1-3-20260527-132854-000`
- **tas-components-v1-3**: `tas-components-v1-3-20260527-133032-000`
- **rekor-monitor-v1-3**: `rekor-monitor-v1-3-20260527-132157-000`
- **segment-backup-job-v1-3**: `segment-backup-job-v1-3-20260527-134528-000`
- **tas-tools-v1-3**: `tas-tools-v1-3-20260527-131748-000`


### Updated Images
- **logsigner-v1-3**: `quay.io/securesign/trillian-logsigner@sha256:53a90af32a452951e2679119bb50122adaab363b85da9943db09c32675a6a562`
- **gitsign-v1-3**: `quay.io/securesign/gitsign@sha256:64799db951d7e3aafe6d40782f8f62c6ffb32001e580d49ef150908309241d56`
- **fetch-tsa-certs-v1-3**: `quay.io/securesign/fetch-tsa-certs@sha256:c79f64d2d1adbc06fe2b2d2d07f4bb82f9fc2fd2222fffb6d93d694c4306f6c9`
- **tuffer-v1-3**: `quay.io/securesign/tuffer@sha256:c696d7be2bf1555a9c7fd7424229d0a3fb59221aad513615732ae0e259012195`
- **database-v1-3**: `quay.io/securesign/trillian-database@sha256:3620f596fbc5d6d3e91e2b60722f08e2e5fe50e3fcf7ce18c81299c191bfebd5`
- **rekor-search-v1-3**: `quay.io/securesign/rekor-search-ui@sha256:e179309a550f4b955523d99d23e3ec43e22187a05e67403335b535b5f093f20f`
- **updatetree-v1-3**: `quay.io/securesign/trillian-updatetree@sha256:4eebe34b0d845edb88b4841f2d3846ebd2034fc2a5a65971db01b52919eeee5f`
- **create-tree-v1-3**: `quay.io/securesign/trillian-createtree@sha256:59fbc05f2572a54b402349ed0c70f91c01c81775202ce16009a34727d12afa03`
- **certificate-transparency-go-v1-3**: `quay.io/securesign/certificate-transparency-go@sha256:534bd8442ddd2167c188a704543f6ddfb4fcd6b6c1ce621e3c097e5f400d4c81`
- **fulcio-server-v1-3**: `quay.io/securesign/fulcio-server@sha256:08882cc1928873a6e9178e7548a7949be48206cb87addd8c42b2d86014a361d1`
- **rekor-cli-v1-3**: `quay.io/securesign/rekor-cli@sha256:c583b047dc18d3cf8afe01ae369d7777954c1e6a396bc0cae370dea9e534eb20`
- **tuf-tool-v1-3**: `quay.io/securesign/cli-tuftool@sha256:e11f202c7ccf06fada3e56c76183950f0efd2e044dfc4534cdedd664dba06618`
- **rekor-server-v1-3**: `quay.io/securesign/rekor-server@sha256:05dc14546eb3f13e6a93b3f42e79fd7ae07217451f91d6038165f201876fb9a1`
- **logserver-v1-3**: `quay.io/securesign/trillian-logserver@sha256:fa8b0f9b7830fe0f6cb812e4d249f703f7e21c0d8342180627004b57ce2285df`
- **rekor-monitor-v1-3**: `quay.io/securesign/rekor-monitor@sha256:afbbcd0d319a76f00e0e74cbfff66128d0220652552fa049b3e9db596fbd59b1`
- **segment-backup-job-v1-3**: `quay.io/securesign/segment-backup-job@sha256:8f377dac28a9046bb0ef05dd1483467d4b47ba9e7f19ae2be3cb377c069b22bc`
- **cosign-v1-3**: `quay.io/securesign/cli-cosign@sha256:070d379aef356b0e32a54cf6a9d1fbf606721f436c4464f1d20b6b0f1f15d3bb`
- **timestamp-authority-v1-3**: `quay.io/securesign/timestamp-authority@sha256:84d618216dca549a0697817368d2283414d0ea71a2d2dd66479498c4ccf80bef`
- **redis-v1-3**: `quay.io/securesign/trillian-redis@sha256:f3ef42c94b9c6a33f2d393f8c0b8fb2b09a60b2cdc4bcd829b8c23f0b9ce6959`
- **backfill-redis-v1-3**: `quay.io/securesign/rekor-backfill-redis@sha256:ae98ffe33af08c7e620122862ef98e6d9745723a5d0cdf55310942dcc86da83b`



🤖 Generated automatically by one-button-build