### PR TITLE
Update client images from build 2026-05-28

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,40 +1,40 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:5fd5251973239b8902d9fd297c8636d1992deeec324ab91235e590ac714f9260 AS cosign-amd64
-FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:6383853a3396f2b26acfe6352428574314c3200d90e5ce125d3cc3c6ee93f794 AS cosign-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:c77afc5fec6a203a1713e85a6beafe1e644190460d3d2ffe2c1104eeeeb967a0 AS cosign-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:55c21b13da1b63a47660188848de7cc2b5e206eff24ff21c6fbb4aff3a6e0389 AS cosign-s390x
+FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:83744c67787c8ed8ba24e1051ab7be9b1ca3ea36afaa0f7a2a8759b7639258e3 AS cosign-amd64
+FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:83744c67787c8ed8ba24e1051ab7be9b1ca3ea36afaa0f7a2a8759b7639258e3 AS cosign-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:83744c67787c8ed8ba24e1051ab7be9b1ca3ea36afaa0f7a2a8759b7639258e3 AS cosign-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:83744c67787c8ed8ba24e1051ab7be9b1ca3ea36afaa0f7a2a8759b7639258e3 AS cosign-s390x
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:2e655e1da4872062d38eafbe8e6f5658ad3330103407383605c33e86b6f4adde AS gitsign-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:f15ed2c2bfd1f6ceb496fea1f37b00b84d023a66863b7dc703fa4f92e3a7c93a AS gitsign-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:5779f5d553f19461e04b218a65b56911a73c64d084f18d964f3acb71a9ce422d AS gitsign-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:c1a4b60442c7ae5c01ff6e83228f4cbc4c58d26f26f86d24abef7b55e6d17796 AS gitsign-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:a4aae22ed64b25ea1124aed133e8751811e6b9be8a7c11ea7f06eca61e2579fc AS gitsign-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:a4aae22ed64b25ea1124aed133e8751811e6b9be8a7c11ea7f06eca61e2579fc AS gitsign-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:a4aae22ed64b25ea1124aed133e8751811e6b9be8a7c11ea7f06eca61e2579fc AS gitsign-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:a4aae22ed64b25ea1124aed133e8751811e6b9be8a7c11ea7f06eca61e2579fc AS gitsign-s390x
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM --platform=linux/amd64 quay.io/securesign/fetch-tsa-certs@sha256:b0e5b6defc664dfeca7cca0dea36d4e209969efd3312998bc71c10ec4b6d2250 as fetch_tsa_certs-amd64
-FROM --platform=linux/arm64 quay.io/securesign/fetch-tsa-certs@sha256:c43c8a021faf0050ab2a030ccfc2e8a4058cc9ec75412db3e17d1c6846565894 as fetch_tsa_certs-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:a26796b80b58dcb329c5e2ce8b8b7ffdb0bcb787d0411d47f746c1a0998f3702 as fetch_tsa_certs-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/fetch-tsa-certs@sha256:7019d659fe77828cc9dead16760ecf8314e7b55cb0cf68c6e2f2470638a86558 as fetch_tsa_certs-s390x
+FROM --platform=linux/amd64 quay.io/securesign/fetch-tsa-certs@sha256:7f9161472efbee1efe7fb85d9f478bb9a7e204689b6ff584051ae78e04906e81 as fetch_tsa_certs-amd64
+FROM --platform=linux/arm64 quay.io/securesign/fetch-tsa-certs@sha256:7f9161472efbee1efe7fb85d9f478bb9a7e204689b6ff584051ae78e04906e81 as fetch_tsa_certs-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:7f9161472efbee1efe7fb85d9f478bb9a7e204689b6ff584051ae78e04906e81 as fetch_tsa_certs-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/fetch-tsa-certs@sha256:7f9161472efbee1efe7fb85d9f478bb9a7e204689b6ff584051ae78e04906e81 as fetch_tsa_certs-s390x
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM --platform=linux/amd64 quay.io/securesign/rekor-cli@sha256:253f59a58a47dcf5230fd4977026787d46fed5a766174b53787787edf16befb7 as rekor-amd64
-FROM --platform=linux/arm64 quay.io/securesign/rekor-cli@sha256:6c991091871ebeb6d9aef869203a1868842e49193cb483d345685ccd88c9e64f as rekor-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:84af62ef90352bfcb95324d86750f9075b26e2cfd4a3655f393f224ae928c953 as rekor-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/rekor-cli@sha256:e8058370738ebaf462e4e712dd02f83291c5cb21fc30984c7c509ee5e580c0db as rekor-s390x
+FROM --platform=linux/amd64 quay.io/securesign/rekor-cli@sha256:26b4c828ed937ecb56c4bc768ad395102b3a864fe8f0f6d2aad1e0728c8c66cb as rekor-amd64
+FROM --platform=linux/arm64 quay.io/securesign/rekor-cli@sha256:26b4c828ed937ecb56c4bc768ad395102b3a864fe8f0f6d2aad1e0728c8c66cb as rekor-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:26b4c828ed937ecb56c4bc768ad395102b3a864fe8f0f6d2aad1e0728c8c66cb as rekor-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/rekor-cli@sha256:26b4c828ed937ecb56c4bc768ad395102b3a864fe8f0f6d2aad1e0728c8c66cb as rekor-s390x
 
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776979197@sha256:52ff87e53a584265e5cdb67551e123185e3b3937cfecf2f0ac486894fc44c4d1 as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM --platform=linux/amd64 quay.io/securesign/trillian-createtree@sha256:d05ca8ed661009c68e6964f8fdebde0b8ff5b8bfc63757c9d67f4e9d34caa449 as trillian-createtree-amd64
-FROM --platform=linux/arm64 quay.io/securesign/trillian-createtree@sha256:170f40a5918f434f489abde2ee154030c9321053ab5ad0d8559d1de68874c84f as trillian-createtree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:caae5b258ff276cf75f305931131a7f26c44a562255ca7e7708e23c9ab79fc8a as trillian-createtree-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/trillian-createtree@sha256:ca8c1450f7c59f84ebbb847fa6b69130e0027c92fd92d016eaf34acbc25fed67 as trillian-createtree-s390x
+FROM --platform=linux/amd64 quay.io/securesign/trillian-createtree@sha256:63097050f64bb94f990daa4226dbcabf427bdb853d8a3e9c79101ac90c6f3711 as trillian-createtree-amd64
+FROM --platform=linux/arm64 quay.io/securesign/trillian-createtree@sha256:63097050f64bb94f990daa4226dbcabf427bdb853d8a3e9c79101ac90c6f3711 as trillian-createtree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:63097050f64bb94f990daa4226dbcabf427bdb853d8a3e9c79101ac90c6f3711 as trillian-createtree-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/trillian-createtree@sha256:63097050f64bb94f990daa4226dbcabf427bdb853d8a3e9c79101ac90c6f3711 as trillian-createtree-s390x
 
-FROM --platform=linux/amd64 quay.io/securesign/trillian-updatetree@sha256:a8faaae4b7c8c0db529951e3d4937cabaf84a9569004c72cdbde900101632ff1 as trillian-updatetree-amd64
-FROM --platform=linux/arm64 quay.io/securesign/trillian-updatetree@sha256:3dc96414da356bc7db6ab80aa5f1ea840bfec1a3f68fe1d85a56c2479c64ce27 as trillian-updatetree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:6b559dc73c7f1e0bf5dc36700a16fe7261267987b28a1c385d1329a75d8f21ae as trillian-updatetree-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/trillian-updatetree@sha256:2f255abb8d3d27452f83cadba766d2000ee48e6107904ce7495c51c986881ea1 as trillian-updatetree-s390x
+FROM --platform=linux/amd64 quay.io/securesign/trillian-updatetree@sha256:4dcc7475f06622d7c73916b48613b6501b6e631aae2b574b20eb0dfa616444ce as trillian-updatetree-amd64
+FROM --platform=linux/arm64 quay.io/securesign/trillian-updatetree@sha256:4dcc7475f06622d7c73916b48613b6501b6e631aae2b574b20eb0dfa616444ce as trillian-updatetree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:4dcc7475f06622d7c73916b48613b6501b6e631aae2b574b20eb0dfa616444ce as trillian-updatetree-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/trillian-updatetree@sha256:4dcc7475f06622d7c73916b48613b6501b6e631aae2b574b20eb0dfa616444ce as trillian-updatetree-s390x
 
-FROM quay.io/securesign/cli-tuftool@sha256:96dd680be18d8d1c3eced452b9f455769fc5b94761dd72bb7cb76b1d3d19b637 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:0b5fce06b3367d251f68a26e528a6733e1e4329d4284e6a8ea2367a1cb3f2225 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:e44ddd84a5d86c800f758ae0f09ebe321ec997d0e546c80db6ea8263c6a054d8
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **create-tree-v1-4**: `create-tree-v1-4-20260528-082433-000`
- **tas-components-v1-4**: `tas-components-v1-4-20260528-082344-000`
- **rekor-monitor-v1-4**: `rekor-monitor-v1-4-20260528-082839-000`
- **tas-tools-v1-4**: `tas-tools-v1-4-20260528-082329-000`
- **tough-v1-4**: `tough-v1-4-20260528-082519-000`


### Updated Images
- **rekor-cli-v1-4**: `quay.io/securesign/rekor-cli@sha256:26b4c828ed937ecb56c4bc768ad395102b3a864fe8f0f6d2aad1e0728c8c66cb`
- **updatetree-v1-4**: `quay.io/securesign/trillian-updatetree@sha256:4dcc7475f06622d7c73916b48613b6501b6e631aae2b574b20eb0dfa616444ce`
- **tuffer-v1-4**: `quay.io/securesign/tuffer@sha256:e294fff80506c3b5adf8ef3764daa56f83a6ca8f11319d030f9d9f96d8123e82`
- **certificate-transparency-go-v1-4**: `quay.io/securesign/certificate-transparency-go@sha256:f06ad84a6e775d3f9e9851d2366cb0323fd331d4f6fb13455859b3efdca71fb3`
- **database-v1-4**: `quay.io/securesign/trillian-database@sha256:877657f392a007cb4b55b7722c4faeaadf7ced5471bf59692cdbb049508125cf`
- **fulcio-server-v1-4**: `quay.io/securesign/fulcio-server@sha256:4bdf184ffc376d349f78745eef328d11b40e505af3418ecd3b9be0d18f288dd7`
- **rekor-search-v1-4**: `quay.io/securesign/rekor-search-ui@sha256:bb16977801728ebec08ab5e10ae4d3ef8380c971b61d36342a581a77538e4ed9`
- **rekor-server-v1-4**: `quay.io/securesign/rekor-server@sha256:0355f6223dbfedb31a466858c5721e25321241ec39da2fd75ffaa1a050097254`
- **redis-v1-4**: `quay.io/securesign/trillian-redis@sha256:5411c86d5ee51af07882624e38a2ffd1c76190715dfff4509c0ccd137e4484a4`
- **ctlog-monitor-v1-4**: `quay.io/securesign/ctlog-monitor@sha256:580a42deec3dfcf675725e5d25586ac584aa32677b35fbc380e85f7f01300318`
- **rekor-monitor-v1-4**: `quay.io/securesign/rekor-monitor@sha256:9c2f61f5f31e3ea1c0cfecff3e57907033a889e2b0fe2e5ff09378e57a5d90dd`
- **gitsign-v1-4**: `quay.io/securesign/gitsign@sha256:a4aae22ed64b25ea1124aed133e8751811e6b9be8a7c11ea7f06eca61e2579fc`
- **tuf-tool-v1-4**: `quay.io/securesign/cli-tuftool@sha256:0b5fce06b3367d251f68a26e528a6733e1e4329d4284e6a8ea2367a1cb3f2225`
- **logserver-v1-4**: `quay.io/securesign/trillian-logserver@sha256:f932e67106084b05d86196d663fa84fd9b22aca2e34eb68d2bb75b87f369ff29`
- **create-tree-v1-4**: `quay.io/securesign/trillian-createtree@sha256:63097050f64bb94f990daa4226dbcabf427bdb853d8a3e9c79101ac90c6f3711`
- **backfill-redis-v1-4**: `quay.io/securesign/rekor-backfill-redis@sha256:cfce2979b325e0fb8845390ad7935ccc45681427161fdae84e8469aa6f9aad58`
- **logsigner-v1-4**: `quay.io/securesign/trillian-logsigner@sha256:ee16dc11257bde36bc297c0a9dd4094537b802a77fd748e09378d457ee6e77eb`
- **timestamp-authority-v1-4**: `quay.io/securesign/timestamp-authority@sha256:8766c29bfc540620a82ff02947787d95271eeb01627fd099524e6661ea462313`
- **cosign-v1-4**: `quay.io/securesign/cli-cosign@sha256:83744c67787c8ed8ba24e1051ab7be9b1ca3ea36afaa0f7a2a8759b7639258e3`
- **fetch-tsa-certs-v1-4**: `quay.io/securesign/fetch-tsa-certs@sha256:7f9161472efbee1efe7fb85d9f478bb9a7e204689b6ff584051ae78e04906e81`



🤖 Generated automatically by one-button-build