### PR TITLE
Update client images from build 2026-05-28

### DIFF
--- a/Dockerfile.clients.rh
+++ b/Dockerfile.clients.rh
@@ -1,40 +1,40 @@
 # Provides the Trusted Artifact Signer CLI binaries, cosign and gitsign
-FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:5fd5251973239b8902d9fd297c8636d1992deeec324ab91235e590ac714f9260 AS cosign-amd64
-FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:6383853a3396f2b26acfe6352428574314c3200d90e5ce125d3cc3c6ee93f794 AS cosign-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:c77afc5fec6a203a1713e85a6beafe1e644190460d3d2ffe2c1104eeeeb967a0 AS cosign-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:55c21b13da1b63a47660188848de7cc2b5e206eff24ff21c6fbb4aff3a6e0389 AS cosign-s390x
+FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:f034b7e43ba63df08502e869d721504f2be7aa515c837a8b31ef430f8faab372 AS cosign-amd64
+FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:f034b7e43ba63df08502e869d721504f2be7aa515c837a8b31ef430f8faab372 AS cosign-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:f034b7e43ba63df08502e869d721504f2be7aa515c837a8b31ef430f8faab372 AS cosign-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:f034b7e43ba63df08502e869d721504f2be7aa515c837a8b31ef430f8faab372 AS cosign-s390x
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:2e655e1da4872062d38eafbe8e6f5658ad3330103407383605c33e86b6f4adde AS gitsign-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:f15ed2c2bfd1f6ceb496fea1f37b00b84d023a66863b7dc703fa4f92e3a7c93a AS gitsign-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:5779f5d553f19461e04b218a65b56911a73c64d084f18d964f3acb71a9ce422d AS gitsign-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:c1a4b60442c7ae5c01ff6e83228f4cbc4c58d26f26f86d24abef7b55e6d17796 AS gitsign-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:d980c4de59e1efa99b4d2377e023d46d946e1a9ff254589a48d87b42618018ca AS gitsign-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:d980c4de59e1efa99b4d2377e023d46d946e1a9ff254589a48d87b42618018ca AS gitsign-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:d980c4de59e1efa99b4d2377e023d46d946e1a9ff254589a48d87b42618018ca AS gitsign-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:d980c4de59e1efa99b4d2377e023d46d946e1a9ff254589a48d87b42618018ca AS gitsign-s390x
 
 # Provides the Trusted Artifact Signer CLI binary, fetch-tsa-certs
-FROM --platform=linux/amd64 quay.io/securesign/fetch-tsa-certs@sha256:b0e5b6defc664dfeca7cca0dea36d4e209969efd3312998bc71c10ec4b6d2250 as fetch_tsa_certs-amd64
-FROM --platform=linux/arm64 quay.io/securesign/fetch-tsa-certs@sha256:c43c8a021faf0050ab2a030ccfc2e8a4058cc9ec75412db3e17d1c6846565894 as fetch_tsa_certs-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:a26796b80b58dcb329c5e2ce8b8b7ffdb0bcb787d0411d47f746c1a0998f3702 as fetch_tsa_certs-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/fetch-tsa-certs@sha256:7019d659fe77828cc9dead16760ecf8314e7b55cb0cf68c6e2f2470638a86558 as fetch_tsa_certs-s390x
+FROM --platform=linux/amd64 quay.io/securesign/fetch-tsa-certs@sha256:d4d549c47fe3204946142898f3863dc1f5b9011b8d4609a4aef109a77932c780 as fetch_tsa_certs-amd64
+FROM --platform=linux/arm64 quay.io/securesign/fetch-tsa-certs@sha256:d4d549c47fe3204946142898f3863dc1f5b9011b8d4609a4aef109a77932c780 as fetch_tsa_certs-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/fetch-tsa-certs@sha256:d4d549c47fe3204946142898f3863dc1f5b9011b8d4609a4aef109a77932c780 as fetch_tsa_certs-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/fetch-tsa-certs@sha256:d4d549c47fe3204946142898f3863dc1f5b9011b8d4609a4aef109a77932c780 as fetch_tsa_certs-s390x
 
 # Provides the Trusted Artifact Signer CLI binaries, rekor-cli and ec
-FROM --platform=linux/amd64 quay.io/securesign/rekor-cli@sha256:253f59a58a47dcf5230fd4977026787d46fed5a766174b53787787edf16befb7 as rekor-amd64
-FROM --platform=linux/arm64 quay.io/securesign/rekor-cli@sha256:6c991091871ebeb6d9aef869203a1868842e49193cb483d345685ccd88c9e64f as rekor-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:84af62ef90352bfcb95324d86750f9075b26e2cfd4a3655f393f224ae928c953 as rekor-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/rekor-cli@sha256:e8058370738ebaf462e4e712dd02f83291c5cb21fc30984c7c509ee5e580c0db as rekor-s390x
+FROM --platform=linux/amd64 quay.io/securesign/rekor-cli@sha256:fcb5801b267d8ede9819fdb580fcec4ed8be4c8d74d699bbca38871cc7903ef9 as rekor-amd64
+FROM --platform=linux/arm64 quay.io/securesign/rekor-cli@sha256:fcb5801b267d8ede9819fdb580fcec4ed8be4c8d74d699bbca38871cc7903ef9 as rekor-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:fcb5801b267d8ede9819fdb580fcec4ed8be4c8d74d699bbca38871cc7903ef9 as rekor-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/rekor-cli@sha256:fcb5801b267d8ede9819fdb580fcec4ed8be4c8d74d699bbca38871cc7903ef9 as rekor-s390x
 
 FROM registry.redhat.io/rhtas/ec-rhel9:0.8-1776979197@sha256:52ff87e53a584265e5cdb67551e123185e3b3937cfecf2f0ac486894fc44c4d1 as ec
 
 # Provides the Trusted Artifact Signer CLI binaries trillian-createtree and trillian-updatetree
-FROM --platform=linux/amd64 quay.io/securesign/trillian-createtree@sha256:d05ca8ed661009c68e6964f8fdebde0b8ff5b8bfc63757c9d67f4e9d34caa449 as trillian-createtree-amd64
-FROM --platform=linux/arm64 quay.io/securesign/trillian-createtree@sha256:170f40a5918f434f489abde2ee154030c9321053ab5ad0d8559d1de68874c84f as trillian-createtree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:caae5b258ff276cf75f305931131a7f26c44a562255ca7e7708e23c9ab79fc8a as trillian-createtree-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/trillian-createtree@sha256:ca8c1450f7c59f84ebbb847fa6b69130e0027c92fd92d016eaf34acbc25fed67 as trillian-createtree-s390x
+FROM --platform=linux/amd64 quay.io/securesign/trillian-createtree@sha256:6905e7f791a9bd537b3ebb1a7f0187089be05d334b8c9e388f0aeb80873cc967 as trillian-createtree-amd64
+FROM --platform=linux/arm64 quay.io/securesign/trillian-createtree@sha256:6905e7f791a9bd537b3ebb1a7f0187089be05d334b8c9e388f0aeb80873cc967 as trillian-createtree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:6905e7f791a9bd537b3ebb1a7f0187089be05d334b8c9e388f0aeb80873cc967 as trillian-createtree-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/trillian-createtree@sha256:6905e7f791a9bd537b3ebb1a7f0187089be05d334b8c9e388f0aeb80873cc967 as trillian-createtree-s390x
 
-FROM --platform=linux/amd64 quay.io/securesign/trillian-updatetree@sha256:a8faaae4b7c8c0db529951e3d4937cabaf84a9569004c72cdbde900101632ff1 as trillian-updatetree-amd64
-FROM --platform=linux/arm64 quay.io/securesign/trillian-updatetree@sha256:3dc96414da356bc7db6ab80aa5f1ea840bfec1a3f68fe1d85a56c2479c64ce27 as trillian-updatetree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:6b559dc73c7f1e0bf5dc36700a16fe7261267987b28a1c385d1329a75d8f21ae as trillian-updatetree-ppc64le
-FROM --platform=linux/s390x quay.io/securesign/trillian-updatetree@sha256:2f255abb8d3d27452f83cadba766d2000ee48e6107904ce7495c51c986881ea1 as trillian-updatetree-s390x
+FROM --platform=linux/amd64 quay.io/securesign/trillian-updatetree@sha256:70cb3279676b4d7a65390c8ad2f938b6fc5e193e51095da2ea3c84678185c1cb as trillian-updatetree-amd64
+FROM --platform=linux/arm64 quay.io/securesign/trillian-updatetree@sha256:70cb3279676b4d7a65390c8ad2f938b6fc5e193e51095da2ea3c84678185c1cb as trillian-updatetree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:70cb3279676b4d7a65390c8ad2f938b6fc5e193e51095da2ea3c84678185c1cb as trillian-updatetree-ppc64le
+FROM --platform=linux/s390x quay.io/securesign/trillian-updatetree@sha256:70cb3279676b4d7a65390c8ad2f938b6fc5e193e51095da2ea3c84678185c1cb as trillian-updatetree-s390x
 
-FROM quay.io/securesign/cli-tuftool@sha256:96dd680be18d8d1c3eced452b9f455769fc5b94761dd72bb7cb76b1d3d19b637 as tuf-tool
+FROM quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5 as tuf-tool
 
 FROM registry.redhat.io/ubi9/httpd-24@sha256:e44ddd84a5d86c800f758ae0f09ebe321ec997d0e546c80db6ea8263c6a054d8
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
## Summary
This PR updates the client images in `Dockerfile.clients.rh` with the latest builds.

### Snapshots
- **rekor-monitor-v1-4**: `rekor-monitor-v1-4-20260528-104301-000`
- **tas-tools-v1-4**: `tas-tools-v1-4-20260528-092041-000`
- **tough-v1-4**: `tough-v1-4-20260528-110144-000`
- **create-tree-v1-4**: `create-tree-v1-4-20260528-111508-000`
- **tas-components-v1-4**: `tas-components-v1-4-20260528-104200-000`


### Updated Images
- **cosign-v1-4**: `quay.io/securesign/cli-cosign@sha256:f034b7e43ba63df08502e869d721504f2be7aa515c837a8b31ef430f8faab372`
- **updatetree-v1-4**: `quay.io/securesign/trillian-updatetree@sha256:70cb3279676b4d7a65390c8ad2f938b6fc5e193e51095da2ea3c84678185c1cb`
- **tuffer-v1-4**: `quay.io/securesign/tuffer@sha256:b690512dc86176acbb3c71e898694dbc14f336a4ff04434b5b0eb59f639a248d`
- **create-tree-v1-4**: `quay.io/securesign/trillian-createtree@sha256:6905e7f791a9bd537b3ebb1a7f0187089be05d334b8c9e388f0aeb80873cc967`
- **fulcio-server-v1-4**: `quay.io/securesign/fulcio-server@sha256:39bb3b1a9b365d06d194af1607790c2aa7998db8a849cba0ac3a005691522800`
- **redis-v1-4**: `quay.io/securesign/trillian-redis@sha256:052018f4efa38633f44410bca75b8d95f403afdce3d5954e08f3dcc2066880ca`
- **rekor-search-v1-4**: `quay.io/securesign/rekor-search-ui@sha256:e27f7f4d8714c50748a097aec25645830fdfe3d03499090e2edd3b5a541f413b`
- **logserver-v1-4**: `quay.io/securesign/trillian-logserver@sha256:eb0c56e96c64d2c5401088f4374a9976e6fc776b343bff7801eb38b5b1e1f893`
- **rekor-monitor-v1-4**: `quay.io/securesign/rekor-monitor@sha256:62c7134b508534e778fcd4de0d284e00e9afbc7693bf83fed0094fe9b27c3f19`
- **fetch-tsa-certs-v1-4**: `quay.io/securesign/fetch-tsa-certs@sha256:d4d549c47fe3204946142898f3863dc1f5b9011b8d4609a4aef109a77932c780`
- **tuf-tool-v1-4**: `quay.io/securesign/cli-tuftool@sha256:af32938bcec6f57f9f9409b166868bc533d7896919b0238268acf44768a1b0c5`
- **database-v1-4**: `quay.io/securesign/trillian-database@sha256:a28e2b01e52cf4e2567a40e0a2748138e21d6bb1f10d959eccd3b0c5ba26236c`
- **logsigner-v1-4**: `quay.io/securesign/trillian-logsigner@sha256:df5aff31928c3f11cc8274c484c1a3e23bc8025a86b909533f9e305aa092cb97`
- **rekor-server-v1-4**: `quay.io/securesign/rekor-server@sha256:5e41601573f076faf144bb49d069dc341624b94af8bb2cd5421103cc18c7c395`
- **gitsign-v1-4**: `quay.io/securesign/gitsign@sha256:d980c4de59e1efa99b4d2377e023d46d946e1a9ff254589a48d87b42618018ca`
- **rekor-cli-v1-4**: `quay.io/securesign/rekor-cli@sha256:fcb5801b267d8ede9819fdb580fcec4ed8be4c8d74d699bbca38871cc7903ef9`
- **backfill-redis-v1-4**: `quay.io/securesign/rekor-backfill-redis@sha256:6d39436f925fd79fd3c23289091a2605fd7c509bc989f63085486bc40da88a6c`
- **certificate-transparency-go-v1-4**: `quay.io/securesign/certificate-transparency-go@sha256:85b3a1fbe2f15e971e149975f7458e201da85affe05ff09a259d93d987b8da1e`
- **timestamp-authority-v1-4**: `quay.io/securesign/timestamp-authority@sha256:8bcb0c3d154bb2fa2adc2dffc61a1a2ab4d71919d7ae7dffa13b350cda6750b3`
- **ctlog-monitor-v1-4**: `quay.io/securesign/ctlog-monitor@sha256:ac070481b9a53e6466dc1b72d668d7010cc246b82f8a4f7cc86fa39a4455e1c6`



🤖 Generated automatically by one-button-build