### PR TITLE
fix: disable hermetic builds for conforma cli-stacks v1.4

### DIFF
--- a/.tekton/conforma-cli-stack-pull-request.yaml
+++ b/.tekton/conforma-cli-stack-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/conforma-cli-stack-push.yaml
+++ b/.tekton/conforma-cli-stack-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Disable hermetic builds in conforma cli-stack Tekton pipelines for release-1.4
- Allows network access during builds for dependency resolution
- Aligns conforma configuration with cosign cli-stack (which already has hermetic: false)

## Changes
- Set `hermetic: "false"` in `.tekton/conforma-cli-stack-pull-request.yaml`
- Set `hermetic: "false"` in `.tekton/conforma-cli-stack-push.yaml`

## Reason
Hermetic builds were preventing the conforma cli-stack pipelines from accessing network resources needed for dependency resolution. This aligns conforma with:
- The cosign cli-stack configuration (already has hermetic: false)
- Other cli-stacks components (rekor, trillian, tough, timestamp-authority, gitsign)

## Test plan
- [ ] Verify PR pipeline triggers and builds successfully
- [ ] Verify push pipeline builds after merge
- [ ] Confirm cli-stack image is published to quay.io/securesign/conforma-cli-stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)