### PR TITLE
feat: add native Go 1.26 FIPS 140-3 runtime guards

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -17,11 +17,11 @@ LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION)
         -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
         -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
         -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
-FIPS_MODULE ?= latest
+FIPS_MODULE ?= v1.0.0
 
 .PHONY: cosign-linux
-cosign-linux: ## Build native Linux binary (FIPS, CGO)
-	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -o cosign -buildvcs=false -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign
+cosign-linux: ## Build native Linux binary (FIPS)
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) go build -tags=no_openssl -o cosign -buildvcs=false -trimpath -ldflags "$(LDFLAGS) -w -s" ./cmd/cosign
 
 .PHONY:
 cross-platform: cosign-darwin-arm64 cosign-darwin-amd64 cosign-windows-amd64 ## Build all distributable (cross-platform) binaries

--- a/Dockerfile.cosign.rh
+++ b/Dockerfile.cosign.rh
@@ -6,6 +6,7 @@ COPY . .
 USER root
 RUN git config --global --add safe.directory /cosign && \
     git update-index --assume-unchanged Dockerfile.cosign.rh && \
+    go mod edit -godebug=fips140=auto && \
     go mod vendor && \
     make -f Build.mak cosign-linux && \
     git update-index --no-assume-unchanged Dockerfile.cosign.rh

--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -18,6 +18,7 @@ package generate
 import (
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"errors"
 	"fmt"
 	"io"
@@ -48,6 +49,15 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, outputKeyPrefixVal s
 	publicKeyFileName := outputKeyPrefixVal + ".pub"
 
 	if kmsVal != "" {
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if fips140.Enabled() && strings.HasPrefix(kmsVal, "azurekms://") && os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH") != "" { //nolint:forbidigo
+			return fmt.Errorf("azure KMS with certificate authentication (AZURE_CLIENT_CERTIFICATE_PATH) is not available in FIPS 140-3 mode: " +
+				"PKCS#12 certificate parsing uses non-FIPS-approved algorithms (SHA-1, 3DES), " +
+				"use managed identity, client secret, or federated OIDC authentication instead")
+		}
+		// ========================================
+
 		k, err := kms.Get(ctx, kmsVal, crypto.SHA256)
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -16,6 +16,7 @@ package options
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -135,14 +136,26 @@ func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Op
 	case o.Keychain != nil:
 		opts = append(opts, remote.WithAuthFromKeychain(o.Keychain))
 	case o.KubernetesKeychain:
-		kc := authn.NewMultiKeychain(
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		keychains := []authn.Keychain{
 			authn.DefaultKeychain,
 			google.Keychain,
 			authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))),
-			authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
-			authn.NewKeychainFromHelper(alibabaacr.NewACRHelper().WithLoggerOut(io.Discard)),
 			github.Keychain,
-		)
+		}
+		if !fips140.Enabled() {
+			keychains = append(keychains,
+				authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
+				authn.NewKeychainFromHelper(alibabaacr.NewACRHelper().WithLoggerOut(io.Discard)),
+			)
+		} else {
+			fmt.Fprintln(os.Stderr, "WARNING: FIPS 140-3 mode enabled: Azure ACR and Alibaba ACR credential helpers "+
+				"are disabled because they use non-FIPS-approved algorithms (MD5, SHA-1). "+
+				"Use --registry-username/--registry-password for these registries instead.")
+		}
+		kc := authn.NewMultiKeychain(keychains...)
+		// ========================================
 		opts = append(opts, remote.WithAuthFromKeychain(kc))
 	case o.AuthConfig.Username != "" && o.AuthConfig.Password != "":
 		opts = append(opts, remote.WithAuth(&authn.Basic{Username: o.AuthConfig.Username, Password: o.AuthConfig.Password}))

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -17,6 +17,7 @@ package signcommon
 import (
 	"bytes"
 	"context"
+	"crypto/fips140"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -305,10 +306,21 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 				pkcs11Key.Close()
 				return nil, err
 			}
-			if cryptoutils.EqualKeys(pubKey, certFromPKCS11.PublicKey) != nil {
+			// RHTAS FIPS - DO NOT REMOVE
+			// ========================================
+			// EqualKeys may invoke SHA-1 via cryptoutils.SKID on the error path
+			// to generate a diagnostic Subject Key Identifier. This is a
+			// non-cryptographic use (RFC 5280 identifier only), so we suppress
+			// FIPS enforcement rather than blocking the operation.
+			var equalKeysErr error
+			fips140.WithoutEnforcement(func() {
+				equalKeysErr = cryptoutils.EqualKeys(pubKey, certFromPKCS11.PublicKey)
+			})
+			if equalKeysErr != nil {
 				pkcs11Key.Close()
 				return nil, errors.New("pkcs11 key and certificate do not match")
 			}
+			// ========================================
 			leafCert = certFromPKCS11
 			certSigner.Cert = pemBytes
 		}
@@ -337,9 +349,20 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 		if err != nil {
 			return nil, fmt.Errorf("get public key: %w", err)
 		}
-		if cryptoutils.EqualKeys(pk, parsedCert.PublicKey) != nil {
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		// EqualKeys may invoke SHA-1 via cryptoutils.SKID on the error path
+		// to generate a diagnostic Subject Key Identifier. This is a
+		// non-cryptographic use (RFC 5280 identifier only), so we suppress
+		// FIPS enforcement rather than blocking the operation.
+		var equalKeysErr error
+		fips140.WithoutEnforcement(func() {
+			equalKeysErr = cryptoutils.EqualKeys(pk, parsedCert.PublicKey)
+		})
+		if equalKeysErr != nil {
 			return nil, errors.New("public key in certificate does not match the provided public key")
 		}
+		// ========================================
 		pemBytes, err := cryptoutils.MarshalCertificateToPEM(parsedCert)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling certificate to PEM: %w", err)

--- a/pkg/cosign/cue/cue.go
+++ b/pkg/cosign/cue/cue.go
@@ -16,12 +16,44 @@
 package cue
 
 import (
+	"crypto/fips140"
+	"fmt"
+	"os"
+	"strings"
+
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
 	cuejson "cuelang.org/go/encoding/json"
 )
 
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+func checkCUEFIPSImports(entrypoints []string) error {
+	for _, path := range entrypoints {
+		data, err := os.ReadFile(path) // #nosec G304
+		if err != nil {
+			return fmt.Errorf("cannot read CUE policy %q for FIPS validation: %w", path, err)
+		}
+		src := string(data)
+		if strings.Contains(src, `"crypto/md5"`) || strings.Contains(src, `"crypto/sha1"`) {
+			return fmt.Errorf("CUE policy %q imports crypto/md5 or crypto/sha1 which are not available in FIPS 140-3 mode", path)
+		}
+	}
+	return nil
+}
+
+// ========================================
+
 func ValidateJSON(jsonBody []byte, entrypoints []string) error {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		if err := checkCUEFIPSImports(entrypoints); err != nil {
+			return err
+		}
+	}
+	// ========================================
+
 	ctx := cuecontext.New()
 	bis := load.Instances(entrypoints, nil)
 

--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -17,6 +17,7 @@ package github
 
 import (
 	"context"
+	"crypto/fips140"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -44,6 +45,14 @@ func New() *Gh {
 }
 
 func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) error {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return fmt.Errorf("GitHub Actions secret encryption is not available in FIPS 140-3 mode: " +
+			"it requires NaCl box (Curve25519/XSalsa20/Poly1305) which are not FIPS-approved algorithms")
+	}
+	// ========================================
+
 	var httpClient *http.Client
 	if token, ok := env.LookupEnv(env.VariableGitHubToken); ok {
 		ts := oauth2.StaticTokenSource(

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/rsa"
 	_ "crypto/sha256" // for `crypto.SHA256`
@@ -197,6 +198,14 @@ func ImportKeyPair(keyPath string, pf PassFunc) (*KeysBytes, error) {
 }
 
 func marshalKeyPair(ptype string, keypair Keys, pf PassFunc) (key *KeysBytes, err error) {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return nil, fmt.Errorf("password-protected private keys are not supported in FIPS 140-3 mode: " +
+			"key encryption uses scrypt and NaCl SecretBox which are not FIPS-approved algorithms")
+	}
+	// ========================================
+
 	x509Encoded, err := x509.MarshalPKCS8PrivateKey(keypair.private)
 	if err != nil {
 		return nil, fmt.Errorf("x509 encoding private key: %w", err)
@@ -286,6 +295,14 @@ func LoadPrivateKey(key []byte, pass []byte, defaultLoadOptions *[]signature.Loa
 	if p.Type != CosignPrivateKeyPemType && p.Type != SigstorePrivateKeyPemType {
 		return nil, fmt.Errorf("unsupported pem type: %s", p.Type)
 	}
+
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return nil, fmt.Errorf("password-protected private keys are not supported in FIPS 140-3 mode: " +
+			"key decryption uses scrypt and NaCl SecretBox which are not FIPS-approved algorithms")
+	}
+	// ========================================
 
 	x509Encoded, err := encrypted.Decrypt(p.Bytes, pass)
 	if err != nil {

--- a/pkg/cosign/rego/rego.go
+++ b/pkg/cosign/rego/rego.go
@@ -18,6 +18,7 @@ package rego
 import (
 	"bytes"
 	"context"
+	"crypto/fips140"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -44,14 +45,37 @@ type CosignRuleResult struct {
 	Result  bool   `json:"result,omitempty"`
 }
 
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+func fipsRegoOpts() []func(*rego.Rego) {
+	if !fips140.Enabled() {
+		return nil
+	}
+	return []func(*rego.Rego){
+		rego.UnsafeBuiltins(map[string]struct{}{
+			"crypto.md5":       {},
+			"crypto.sha1":      {},
+			"crypto.hmac.md5":  {},
+			"crypto.hmac.sha1": {},
+		}),
+	}
+}
+
+// ========================================
+
 func ValidateJSON(jsonBody []byte, entrypoints []string) []error {
 	ctx := context.Background()
 
-	r := rego.New(
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	opts := []func(*rego.Rego){ //nolint:prealloc
 		rego.Query(QUERY),
 		rego.Load(entrypoints, nil),
 		rego.SetRegoVersion(ast.RegoV0),
-	)
+	}
+	opts = append(opts, fipsRegoOpts()...)
+	// ========================================
+	r := rego.New(opts...)
 
 	query, err := r.PrepareForEval(ctx)
 	if err != nil {
@@ -98,11 +122,16 @@ func ValidateJSONWithModuleInput(jsonBody []byte, moduleInput string) (warnings 
 	query := fmt.Sprintf("%s = data.%s.%s", CosignEvaluationRule, CosignRegoPackageName, CosignEvaluationRule)
 	module := fmt.Sprintf("%s.rego", CosignRegoPackageName)
 
-	r := rego.New(
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	opts := []func(*rego.Rego){ //nolint:prealloc
 		rego.Query(query),
 		rego.Module(module, moduleInput),
 		rego.SetRegoVersion(ast.RegoV0),
-	)
+	}
+	opts = append(opts, fipsRegoOpts()...)
+	// ========================================
+	r := rego.New(opts...)
 
 	evalQuery, err := r.PrepareForEval(ctx)
 	if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/fips140"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
@@ -953,9 +954,20 @@ func keyBytes(sig oci.Signature, co *CheckOpts) ([]byte, error) {
 		}
 	}
 	if cert != nil && co.SigVerifier != nil {
-		if err := cryptoutils.EqualKeys(cert.PublicKey, pub); err != nil {
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		// EqualKeys may invoke SHA-1 via cryptoutils.SKID on the error path
+		// to generate a diagnostic Subject Key Identifier. This is a
+		// non-cryptographic use (RFC 5280 identifier only), so we suppress
+		// FIPS enforcement rather than blocking the operation.
+		var equalKeysErr error
+		fips140.WithoutEnforcement(func() {
+			equalKeysErr = cryptoutils.EqualKeys(cert.PublicKey, pub)
+		})
+		if equalKeysErr != nil {
 			return nil, fmt.Errorf("both public key and certificate were provided but did not match")
 		}
+		// ========================================
 	}
 
 	if cert != nil {

--- a/pkg/policy/eval.go
+++ b/pkg/policy/eval.go
@@ -17,7 +17,9 @@ package policy
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
+	"strings"
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/sigstore/cosign/v3/pkg/cosign/rego"
@@ -56,6 +58,15 @@ func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, pol
 
 // evaluateCue evaluates a cue policy `evaluator` against `attestation`
 func evaluateCue(_ context.Context, attestation []byte, evaluator string) error {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		if strings.Contains(evaluator, `"crypto/md5"`) || strings.Contains(evaluator, `"crypto/sha1"`) {
+			return fmt.Errorf("CUE policy imports crypto/md5 or crypto/sha1 which are not available in FIPS 140-3 mode")
+		}
+	}
+	// ========================================
+
 	cueCtx := cuecontext.New()
 	cueEvaluator := cueCtx.CompileString(evaluator)
 	if cueEvaluator.Err() != nil {

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -17,8 +17,10 @@ package signature
 import (
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/sigstore/cosign/v3/pkg/blob"
@@ -38,9 +40,31 @@ func LoadPublicKey(ctx context.Context, keyRef string) (verifier signature.Verif
 	return VerifierForKeyRef(ctx, keyRef, crypto.SHA256)
 }
 
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+func checkFIPSKMSRef(keyRef string) error {
+	if fips140.Enabled() && strings.HasPrefix(keyRef, "azurekms://") {
+		if os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH") != "" { //nolint:forbidigo
+			return fmt.Errorf("azure KMS with certificate authentication (AZURE_CLIENT_CERTIFICATE_PATH) is not available in FIPS 140-3 mode: " +
+				"PKCS#12 certificate parsing uses non-FIPS-approved algorithms (SHA-1, 3DES), " +
+				"use managed identity, client secret, or federated OIDC authentication instead")
+		}
+	}
+	return nil
+}
+
+// ========================================
+
 // VerifierForKeyRef parses the given keyRef, loads the key and returns an appropriate
 // verifier using the provided hash algorithm
 func VerifierForKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash) (verifier signature.Verifier, err error) {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if err := checkFIPSKMSRef(keyRef); err != nil {
+		return nil, err
+	}
+	// ========================================
+
 	// The key could be plaintext, in a file, at a URL, or in KMS.
 	var perr *kms.ProviderNotFoundError
 	kmsKey, err := kms.Get(ctx, keyRef, hashAlgorithm)
@@ -101,6 +125,13 @@ func SignerFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc) (s
 }
 
 func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption) (signature.SignerVerifier, error) {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if err := checkFIPSKMSRef(keyRef); err != nil {
+		return nil, err
+	}
+	// ========================================
+
 	switch {
 	case strings.HasPrefix(keyRef, pkcs11key.ReferenceScheme):
 		pkcs11UriConfig := pkcs11key.NewPkcs11UriConfig()


### PR DESCRIPTION
## Summary
- Migrate build from CGO OpenSSL FIPS (`CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime`) to Go native FIPS (`CGO_ENABLED=0 GOFIPS140=v1.0.0 -tags=no_openssl`)
- Embed `GODEBUG=fips140=auto` via `go mod edit` in Dockerfile for runtime FIPS auto-detection
- Gate `marshalKeyPair` and `LoadPrivateKey` with `fips140.Enabled()` to block scrypt + NaCl SecretBox (non-FIPS key encryption/decryption)
- Gate `PutSecret` to block NaCl box (GitHub Actions secret encryption)
- Wrap `cryptoutils.EqualKeys` calls with `fips140.WithoutEnforcement` to allow non-cryptographic SHA-1 SKID diagnostic usage (RFC 5280)
- Block Azure KMS with certificate authentication (`AZURE_CLIENT_CERTIFICATE_PATH`) due to PKCS#12 parsing using SHA-1/3DES; other Azure auth methods remain available
- Exclude Azure ACR and Alibaba ACR credential helpers from `--k8s-keychain` in FIPS mode (MD5/SHA-1 usage); Default, Google, ECR, and GitHub keychains remain
- Mark OPA Rego `crypto.md5`, `crypto.sha1`, `crypto.hmac.md5`, `crypto.hmac.sha1` builtins as unsafe via `rego.UnsafeBuiltins`
- Block CUE policies importing `crypto/md5` or `crypto/sha1` in both file-based and inline policy evaluation paths
