### PR TITLE
fix: prevent SHA-1 panic in OIDC authentication flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/buildkite/agent/v3 v3.115.2
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
+	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
@@ -137,7 +138,6 @@ require (
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
-	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -16,10 +16,12 @@ package auth
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/privacy"
@@ -27,6 +29,7 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/providers"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
+	"golang.org/x/oauth2"
 	"golang.org/x/term"
 )
 
@@ -153,7 +156,38 @@ func AuthenticateCaller(flow, idToken, oidcIssuer, oidcClientID, oidcClientSecre
 		return "", "", fmt.Errorf("unsupported oauth flow: %s", flow)
 	}
 
-	tok, err := oauthflow.OIDConnect(oidcIssuer, oidcClientID, oidcClientSecret, oidcRedirectURL, tokenGetter)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// go-jose computes sha1.Sum during JWK parsing (x5t thumbprint) which is
+	// non-cryptographic but would panic under fips140=only.
+	// Same pattern as securesign/gitsign#369.
+	var tok *oauthflow.OIDCIDToken
+	var err error
+	if fips140.Enabled() {
+		if sg, ok := tokenGetter.(*oauthflow.StaticTokenGetter); ok {
+			tok, err = sg.GetIDToken(nil, oauth2.Config{})
+		} else {
+			var provider *oidc.Provider
+			fips140.WithoutEnforcement(func() {
+				provider, err = oidc.NewProvider(context.Background(), oidcIssuer)
+			})
+			if err == nil {
+				config := oauth2.Config{
+					ClientID:     oidcClientID,
+					ClientSecret: oidcClientSecret,
+					Endpoint:     provider.Endpoint(),
+					Scopes:       []string{oidc.ScopeOpenID, "email"},
+					RedirectURL:  oidcRedirectURL,
+				}
+				fips140.WithoutEnforcement(func() {
+					tok, err = tokenGetter.GetIDToken(provider, config)
+				})
+			}
+		}
+	} else {
+		tok, err = oauthflow.OIDConnect(oidcIssuer, oidcClientID, oidcClientSecret, oidcRedirectURL, tokenGetter)
+	}
+	// ========================================
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
## Summary
- Wrap OIDC auth flow with `fips140.WithoutEnforcement()` to prevent
  go-jose SHA-1 x5t thumbprint panic under fips140=only
- Same pattern as securesign/gitsign#369 and securesign/fulcio#401
- Temporary workaround until https://github.com/go-jose/go-jose/pull/219
