### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/conforma-cli-stack-pull-request.yaml
+++ b/.tekton/conforma-cli-stack-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.conforma-cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/conforma-cli-stack-push.yaml
+++ b/.tekton/conforma-cli-stack-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.conforma-cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/cosign-cli-stack-pull-request.yaml
+++ b/.tekton/cosign-cli-stack-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/cosign-cli-stack-push.yaml
+++ b/.tekton/cosign-cli-stack-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/cosign-pull-request.yaml
+++ b/.tekton/cosign-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cosign.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/cosign-push.yaml
+++ b/.tekton/cosign-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cosign.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)