### PR TITLE
Update cli-stacks image digests from Wave 1 builds 2026-07-29

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -13,10 +13,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod vendor && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:00026c71f5dae133359297820e09223c9be437969e32e2ecadbde4fad3aef69f AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:a07c429b837037e9d20bc4c388a9664f0a68485f9d0db11bf714c2b6e5e17153 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:95d3936866f62f24bec6feff682744b23b132596b6dbce202fbc2e51b2be1e6d AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:50b6e465deee19dd1b28095d560eb71df34967ade6aa6c17d8e7fe40b851d7e1 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:81329444e5b04aa79bcf6be042d1cf69931e50ab7a0995da99b561e1891c57b4 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:782b0d84a9c61415ac3dd0319bc3b6e537a63e95a1166ebec03c11298fa0e97f AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:f75f9595a8283adcc7cb2463d6ce59ed3dee72832e1cb0880569c9d41d615cdb AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:e06fd5acd173be692aeb2d1bfb3f8b7bbbdd4bb876c9e18279c87954b974c300 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1784190466@sha256:f99dd81b20e5971ef9f63a51ac27cf0aa591ff9921d021490548b67fd9b17144 AS packager
 USER root


### PR DESCRIPTION
Updates cosign (cli-cosign) per-arch digests in Dockerfile.cli-stack.rh from today's Wave 1 builds.

Source snapshot: tas-tools-v1-4-20260729-115633-000