### PR TITLE
Update cli-stacks image digests from Wave 1 builds 2026-07-30

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -13,10 +13,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod vendor && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:81329444e5b04aa79bcf6be042d1cf69931e50ab7a0995da99b561e1891c57b4 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:782b0d84a9c61415ac3dd0319bc3b6e537a63e95a1166ebec03c11298fa0e97f AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:f75f9595a8283adcc7cb2463d6ce59ed3dee72832e1cb0880569c9d41d615cdb AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:e06fd5acd173be692aeb2d1bfb3f8b7bbbdd4bb876c9e18279c87954b974c300 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/cli-cosign@sha256:c41399a432868f51897c762b2ece554848b06ba40c1f3248dcf100dc2e3d503d AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/cli-cosign@sha256:73501c06ced3fe1a280238b611871b4cd99b646ea2cad5768605f9c1266fc56c AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/cli-cosign@sha256:05184a85ae6e96793f187f93627e8d2ce2c33965df2af53acda0c74955a685a3 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/cli-cosign@sha256:ca97d62040ea5c0d0c79a6f049005aa6045d0ab12cf26ed3895b53326e9c36b9 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1785360201@sha256:272a3dd990bba320c2e246119a0019d10d627d0104938d5db77ba5ab3ae3a51d AS packager
 USER root


### PR DESCRIPTION
## Summary
This PR updates cli-stacks image digests in `Dockerfile.cli-stack.rh` with the latest Wave 1 builds for release 1.4.3.

### Source snapshots
From `releases/1.4.3/snapshots.yaml` Wave 1 builds (2026-07-30).