### PR TITLE
build: enable hermetic builds for cosign cli-stack

### DIFF
--- a/.tekton/cosign-cli-stack-pull-request.yaml
+++ b/.tekton/cosign-cli-stack-pull-request.yaml
@@ -34,8 +34,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/cosign-cli-stack-push.yaml
+++ b/.tekton/cosign-cli-stack-push.yaml
@@ -31,8 +31,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Enable hermetic builds for the `cosign-cli-stack` component (both push and pull-request pipelines)
- Add `prefetch-input` with gomod cachi2 prefetch to both pipelines
- `conforma-cli-stack` already has hermetic enabled, no changes needed there

## Test plan
- [ ] Verify the cosign cli-stack PR build passes with hermetic enabled